### PR TITLE
Class outline broken links

### DIFF
--- a/courses/_posts/2001-01-01-github-foundations-class-plan.md
+++ b/courses/_posts/2001-01-01-github-foundations-class-plan.md
@@ -10,7 +10,7 @@ tags: [outline, course]
 
 This is an outline for a comprehensive class that uses all modules in the `topics` folder.
 
-1. [Switching To Git and GitHub](/topics/Switching-To-Git-and-GitHub.html)
+1. [Switching To Git and GitHub](/articles/moving-to-git-and-github)
 1. [Wireless Setup](/topics/Wireless-Setup.html)
 1. [History of Git](/topics/History-of-Git.html)
 1. [SSH Setup](/topics/SSH-Setup.html)

--- a/courses/_posts/2001-01-01-github-foundations-class-plan.md
+++ b/courses/_posts/2001-01-01-github-foundations-class-plan.md
@@ -11,7 +11,6 @@ tags: [outline, course]
 This is an outline for a comprehensive class that uses all modules in the `topics` folder.
 
 1. [Switching To Git and GitHub](/articles/moving-to-git-and-github)
-1. [Wireless Setup](/topics/Wireless-Setup.html)
 1. [History of Git](/topics/History-of-Git.html)
 1. [SSH Setup](/topics/SSH-Setup.html)
 1. [Setting Up Git](/topics/Setting-Up-Git.html)

--- a/courses/_posts/2001-01-01-github-foundations-class-plan.md
+++ b/courses/_posts/2001-01-01-github-foundations-class-plan.md
@@ -1,44 +1,44 @@
 ---
 layout: barewithrelated
 title: Complete Class Plan
-description: A directed curriculum plan through all our courseware topics.
+description: A directed curriculum plan through all our courseware articles.
 tags: [outline, course]
 ---
 
 
 # Complete Class Outline
 
-This is an outline for a comprehensive class that uses all modules in the `topics` folder.
+This is an outline for a comprehensive class that uses all modules in the `articles` folder.
 
-1. [Switching To Git and GitHub](/articles/moving-to-git-and-github)
-1. [History of Git](/topics/History-of-Git.html)
-1. [SSH Setup](/topics/SSH-Setup.html)
-1. [Setting Up Git](/topics/Setting-Up-Git.html)
-1. [Building a Repository](/topics/Building-a-Repository.html)
-1. [Cloning and Remotes](/topics/Cloning-and-Remotes.html)
-1. [Internals of DotGit](/topics/Internals-of-DotGit.html)
-1. [Everyday Commands](/topics/Everyday-Commands.html)
-1. [Fixing Mistakes](/topics/Fixing-Mistakes.html)
-1. [Branch Creation](/topics/Branch-Creation.html)
-1. [Branch Display](/topics/Branch-Display.html)
-1. [Pushing and Pulling](/topics/Pushing-and-Pulling.html)
-1. [Git Push Contention](/topics/Git-Push-Contention.html)
-1. [Viewing History](/topics/Viewing-History.html)
-1. [Viewing File Contents](/topics/Viewing-Files.html)
-1. [Stash](/topics/Stash.html)
-1. [Tags](/topics/Tags.html)
-1. [Transporting Changes (Patches and Bundles)](/topics/Transporting-Changes-Patches-and-Bundles.html)
-1. [GUIs](/topics/GUIs.html)
-1. [Interoperability with Subversion](/topics/Interoperability-with-Subversion.html)
-1. [Interoperability with Clearcase](/topics/Interoperability-with-Clearcase.html)
-1. [Merging, Rebase, and Rerere](/topics/Merging-Rebase-Rerere.html)
-1. [Power Tools (Grep and Bisect)](/topics/Power-Tools-Grep-and-Bisect.html)
-1. [Repo Maintenance](/topics/Repo-Maintenance.html)
-1. [Servers and WebUIs](/topics/Servers-and-WebUIs.html)
-1. [Continuous Integration](/topics/Continuous-Integration.html)
-1. [Ecosystem](/topics/Ecosystem.html)
-1. [Submodules](/topics/Submodules.html)
-1. [Customizing Git Aliases](/topics/Customizing-Git-Aliases.html)
-1. [Hooks](/topics/Hooks.html)
-1. [Filter Branch](/topics/Filter-Branch.html)
-1. [Extra Tools](/topics/Extra-Tools.html)
+1. [Switching To Git and GitHub](/articles/moving-to-git-and-github/)
+1. [History of Git](/articles/lesson-history-of-git/)
+1. [SSH Setup](/articles/lesson-ssh-setup/)
+1. [Setting Up Git](/articles/lesson-git-initial-setup/)
+1. [Building a Repository](/articles/lesson-repository-creation/)
+1. [Cloning and Remotes](/articles/lesson-git-clone/)
+1. [Internals of DotGit](/articles/lesson-internals-of-dotgit/)
+1. [Everyday Commands](/articles/lesson-git-everyday-commands/)
+1. [Fixing Mistakes](/articles/lesson-fixing-mistakes/)
+1. [Branch Creation](/articles/lesson-branch-creation/)
+1. [Branch Display](/articles/lesson-branch-display/)
+1. [Pushing and Pulling](/articles/lesson-pushing-and-pulling/)
+1. [Git Push Contention](/articles/lesson-git-push-contention/)
+1. [Viewing History](/articles/lesson-git-log-history/)
+1. [Viewing File Contents](/articles/lesson-git-show-files/)
+1. [Stash](/articles/lesson-git-stash/)
+1. [Tags](/articles/lesson-git-tag/)
+1. [Transporting Changes (Patches and Bundles)](/articles/lesson-git-patches-and-bundles/)
+1. [GUIs](/articles/lesson-git-guis/)
+1. [Interoperability with Subversion](/articles/lesson-git-interoperability-with-subversion/)
+1. [Interoperability with Clearcase](/articles/lesson-git-interoperability-with-clearcase/)
+1. [Merging, Rebase, and Rerere](/articles/lesson-git-merge/)
+1. [Git Bisect](/articles/lesson-git-bisect/)
+1. [Repo Maintenance](/articles/lesson-git-repo-maintenance/)
+1. [Servers and WebUIs](/articles/lesson-git-servers-and-web-uis/)
+1. [Continuous Integration](/articles/lesson-continuous-integration/)
+1. [Ecosystem](/articles/lesson-git-ecosystem/)
+1. [Submodules](/articles/lesson-git-submodules/)
+1. [Customizing Git Aliases](/articles/lesson-git-aliases/)
+1. [Hooks](/articles/lesson-git-hooks)
+1. [Filter Branch](/articles/lesson-filter-branch/)
+1. [Extra Tools](/articles/lesson-git-extras-addon/)


### PR DESCRIPTION
@matthewmccullough : Also noticed the `Wireless-Setup` was deleted? i couldn't find it renamed anywhere.

Everything else seems to be under `/technology/` with the prefix of `/articles/lesson-#{title}/`
