### PR TITLE
updated examples to have context to view the repo at that directory

### DIFF
--- a/_layouts/exampleswithrelated.html
+++ b/_layouts/exampleswithrelated.html
@@ -9,12 +9,12 @@
 
     <link rel="stylesheet" media="screen" href="/stylesheets/code.css" type="text/css" />
 	  <link rel="stylesheet" media="screen" href="/stylesheets/page.css" type="text/css" />
-    {% if page.examplesPath %}
+    {% if page.examples %}
     <script src="http://code.jquery.com/jquery-1.8.2.min.js"></script>
     <script src="/components/github-files/index.js"></script>
     <script type = "text/javascript">
-      for(var i = 0; i < "{{page.examplesPath}}".split(" ").length; i++){
-        var filePath = "{{page.examplesPath}}".split(" ")[i];
+      for(var i = 0; i < "{{page.examples}}".split(" ").length; i++){
+        var filePath = "{{page.path}}"+"{{page.examples}}".split(" ")[i];
         (function(filePath){
           $.getGithubFileByFilePath("github", "teach.github.com", filePath, function(contents) {
             $("#example pre code").append("<h3>"+ filePath +"</h3>");
@@ -47,7 +47,7 @@
     <div class="top">
       <header>
         <a href ="/"><img alt="GitHub" class="github-logo-4x" height="30" src="/images/github_training_logo.png"></a>
-        <a href="https://github.com/github/teach.github.com" class="mini-button"><span>R</span>View it on GitHub</a>
+        <a href="https://github.com/github/teach.github.com/blob/gh-pages/{{page.path}}" class="mini-button"><span>R</span>View it on GitHub</a>
       </header>
     </div>
 

--- a/examples/_posts/2001-01-01-example-asciidoc-sample.md
+++ b/examples/_posts/2001-01-01-example-asciidoc-sample.md
@@ -1,7 +1,9 @@
 ---
-layout: barewithrelated
+layout: exampleswithrelated
 title: AsciiDoc Sample
 description: An example of AsciiDoc use and rendering on GitHub.
+path: examples/asciicoc-sample/
+examples: asciicoc-sample.asciidoc
 tags: [example, code]
 ---
 

--- a/examples/_posts/2001-01-01-example-auto-backup-script.md
+++ b/examples/_posts/2001-01-01-example-auto-backup-script.md
@@ -2,7 +2,8 @@
 layout: exampleswithrelated
 title: Automatic Git Commits (Backups)
 description: An example of automatically committing on a timed basis using a script.
-examplesPath: examples/auto-backup-script/auto-backup-script.sh
+path: examples/auto-backup-script/
+examples: auto-backup-script.sh
 tags: [example, code]
 ---
 

--- a/examples/_posts/2001-01-01-example-build-repo-rubytest.md
+++ b/examples/_posts/2001-01-01-example-build-repo-rubytest.md
@@ -2,7 +2,8 @@
 layout: exampleswithrelated
 title: Build a repo with Ruby code using a script
 description: An example of scripting the creation of a repository of Ruby code.
-examplesPath: examples/build-repo-rubytest/0001-Commit-one.patch examples/build-repo-rubytest/0002-Commit-two.patch examples/build-repo-rubytest/build-repo-rubytest.sh
+path: examples/build-repo-rubytest/
+examples: 0001-Commit-one.patch 0002-Commit-two.patch build-repo-rubytest.sh
 tags: [example, code]
 ---
 

--- a/examples/_posts/2001-01-01-example-delete-merged-branches.md
+++ b/examples/_posts/2001-01-01-example-delete-merged-branches.md
@@ -2,7 +2,8 @@
 layout: exampleswithrelated
 title: Script to delete merged branches
 description: An example of scripting the deletion of merged branches.
-examplesPath: examples/delete-merged-branches/delete-merged-remote-branches.sh
+path: examples/delete-merged-branches/
+examples: delete-merged-remote-branches.sh
 tags: [example, code]
 ---
 

--- a/examples/_posts/2001-01-01-example-filter-branch.md
+++ b/examples/_posts/2001-01-01-example-filter-branch.md
@@ -2,7 +2,8 @@
 layout: exampleswithrelated
 title: Demonstrate the use of Git filter-branch
 description: An example of using Git filter-branch to shape a repository.
-examplesPath: examples/filter-branch/test-filter-branch.sh examples/filter-branch/splitgitrepo.pl
+path: examples/filter-branch/
+examples: test-filter-branch.sh splitgitrepo.pl
 tags: [example, code]
 ---
 

--- a/examples/_posts/2001-01-01-example-git-build-mergeable-repo.md
+++ b/examples/_posts/2001-01-01-example-git-build-mergeable-repo.md
@@ -2,7 +2,8 @@
 layout: exampleswithrelated
 title: Build a mergeable Git repo
 description: An example scripted construction of a Git repo.
-examplesPath: examples/git-build-mergeable-repo/git-build-mergeable.sh
+path: examples/git-build-mergeable-repo/
+examples: git-build-mergeable.sh
 tags: [example, code]
 ---
 

--- a/examples/_posts/2001-01-01-example-git-gitconfig.md
+++ b/examples/_posts/2001-01-01-example-git-gitconfig.md
@@ -2,7 +2,8 @@
 layout: exampleswithrelated
 title: Git Config Files
 description: An example of some common Git Config Files.
-examplesPath: examples/gitconfig/dot-gitconfig.txt
+path: examples/gitconfig/
+examples: dot-gitconfig.txt
 tags: [example, code]
 ---
 

--- a/examples/_posts/2001-01-01-example-git-svn-convert-groovy.md
+++ b/examples/_posts/2001-01-01-example-git-svn-convert-groovy.md
@@ -2,7 +2,8 @@
 layout: exampleswithrelated
 title: Git SVN Conversion for the Groovy Project
 description: An example of converting a Subversion repo to Git.
-examplesPath: examples/git-svn-convert-groovy/Groovy-SVN-To-Git-Conversion.bsh
+path: examples/git-svn-convert-groovy/
+examples: Groovy-SVN-To-Git-Conversion.bsh
 tags: [example, code]
 ---
 

--- a/examples/_posts/2001-01-01-example-git-svn-simple-clone.md
+++ b/examples/_posts/2001-01-01-example-git-svn-simple-clone.md
@@ -2,7 +2,8 @@
 layout: exampleswithrelated
 title: Git SVN Simple Clone
 description: An example of using `git svn` to clone a Subversion repository.
-examplesPath: examples/git-svn-simple-clone/clone-a-project.sh
+path: examples/git-svn-simple-clone/
+examples: clone-a-project.sh
 tags: [example, code]
 ---
 


### PR DESCRIPTION
Testing out a way to change the `View it on GitHub` button. 

Currently, Jekyll doesnt allow access of a variable to get the filepath that i know of. Sadly there's nothing like `{{page.name}}` or  `{{page.basename}}` that we can use.

We could use front-matter to set a `path` key for any page we want and just include it in the layout of that file (like I've done with the examples).

If this is something we'd love to see on other pages, comment here and i'll go through other _posts to add the front-matter for `path`
