### PR TITLE
fixed path for example hooks

### DIFF
--- a/examples/_posts/2001-01-01-example-hooks.md
+++ b/examples/_posts/2001-01-01-example-hooks.md
@@ -2,7 +2,7 @@
 layout: exampleswithrelated
 title: Git Hooks
 description: An example of hooks and their power for lifecycle driven activities with Git.
-path: examples/_posts/2001-01-01-example-hooks.md
+path: examples/hooks/
 examples: post-receive-email-SMTP.py
 tags: [example, code]
 ---


### PR DESCRIPTION
Noticed a misspelling from my original branch of this example's path. Fixed it in the same branch after a rebase.
