### PR TITLE
HydeSlides Full Notes & What's Next Support

### DIFF
--- a/presentations/README.md
+++ b/presentations/README.md
@@ -20,6 +20,31 @@ A chapter consists of a `_posts/<yourchapter>` and markdown files consisting of 
 * `title` must be a string or, to hide the slide header, an empty string. e.g. `''`
 * `tags` for simplicity sake is only assigned one value, usually the same name as the chapter folder
 
+## Notes & What's Next Support
+
+### Notes
+
+Speaker notes, only shown on the "split" screen displayed by presseing the S key, are included on slides in an HTML wrapped element with `class="notes"`.
+
+	<aside class="notes">
+	  Oh hey, these are some notes. They'll be hidden in your presentation, but you can see them if you open the speaker notes window (hit 's' on your keyboard).
+	</aside>
+
+### What's Next
+
+HydeSlides has a special implementation to support multiple slide decks and their associated "notes" mirroring mode.
+
+In order to support multiple slide deck HTML files in the root, pass the querystring parameter `name=` with the slide deck (name only) when opening in a browser. 
+
+	http://teach.github.com/presentations/git-foundations.html?name=git-foundations
+
+Pressing S will then correctly launch the slide deck What's Next with presenter notes (if any are in the markup)
+
+	
+## To Do
+*[] Download Google Fonts for offline slide use
+*[] Simplify layouts.scss styles
+
 ## Theming
 
 /dependencies 

--- a/presentations/dependencies/revealjs/plugin/notes/notes.html
+++ b/presentations/dependencies/revealjs/plugin/notes/notes.html
@@ -89,11 +89,11 @@
 	<body>
 
 		<div id="wrap-current-slide" class="slides">
-			<iframe src="../../index.html" width="1280" height="1024" id="current-slide"></iframe>
+			<iframe src="../../../../git-foundations.html" width="1280" height="1024" id="current-slide"></iframe>
 		</div>
 
 		<div id="wrap-next-slide" class="slides">
-			<iframe src="../../index.html" width="640" height="512" id="next-slide"></iframe>
+			<iframe src="../../../../git-foundations.html" width="640" height="512" id="next-slide"></iframe>
 			<span>UPCOMING:</span>
 		</div>
 		<div id="notes"></div>

--- a/presentations/dependencies/revealjs/plugin/notes/notes.html
+++ b/presentations/dependencies/revealjs/plugin/notes/notes.html
@@ -88,12 +88,28 @@
 
 	<body>
 
+		<!-- Current Slide -->
 		<div id="wrap-current-slide" class="slides">
-			<iframe src="../../../../git-foundations.html" width="1280" height="1024" id="current-slide"></iframe>
+			<!--Writing HTML out with script feels dirty-->
+			<script>
+				var slideDeckPath = window.location.search.split("name=")[1]
+				document.write(
+					"<iframe src='../../../../" + slideDeckPath + ".html' width='1280' height='1024' id='current-slide'></iframe>"
+				);
+			</script>
+			
 		</div>
 
+		<!-- What's Next -->
 		<div id="wrap-next-slide" class="slides">
-			<iframe src="../../../../git-foundations.html" width="640" height="512" id="next-slide"></iframe>
+			<!--Writing HTML out with script feels dirty-->
+			<script>
+				var slideDeckPath = window.location.search.split("name=")[1]
+				document.write(
+					"<iframe src='../../../../" + slideDeckPath + ".html' width='640' height='512' id='next-slide'></iframe>"
+				);
+			</script>
+
 			<span>UPCOMING:</span>
 		</div>
 		<div id="notes"></div>

--- a/presentations/dependencies/revealjs/plugin/notes/notes.js
+++ b/presentations/dependencies/revealjs/plugin/notes/notes.js
@@ -5,7 +5,7 @@
 var RevealNotes = (function() {
 
 	function openNotes() {
-		var notesPopup = window.open( 'dependencies/revealjs/plugin/notes/notes.html', 'reveal.js - Notes', 'width=1120,height=850' );
+		var notesPopup = window.open( 'dependencies/revealjs/plugin/notes/notes.html'+window.location.search, 'reveal.js - Notes', 'width=1120,height=850' );
 
 		// Fires when slide is changed
 		Reveal.addEventListener( 'slidechanged', function( event ) {

--- a/presentations/dependencies/revealjs/plugin/notes/notes.js
+++ b/presentations/dependencies/revealjs/plugin/notes/notes.js
@@ -5,7 +5,7 @@
 var RevealNotes = (function() {
 
 	function openNotes() {
-		var notesPopup = window.open( 'plugin/notes/notes.html', 'reveal.js - Notes', 'width=1120,height=850' );
+		var notesPopup = window.open( 'dependencies/revealjs/plugin/notes/notes.html', 'reveal.js - Notes', 'width=1120,height=850' );
 
 		// Fires when slide is changed
 		Reveal.addEventListener( 'slidechanged', function( event ) {


### PR DESCRIPTION
HydeSlides custom implementation of Notes and What's Next features from RevealJS. Now supports n-many slide decks in `/presentations` and support for slit-mode and presenter notes.

Important! Examine the README for the one intricacy of slit-mode support.
