### PR TITLE
Fixed link to GitHub Enterprise benefits post

### DIFF
--- a/usecases/_posts/2001-01-01-moving-to-git-and-github.md
+++ b/usecases/_posts/2001-01-01-moving-to-git-and-github.md
@@ -156,7 +156,7 @@ Thankfully, the idea of using git and SVN together is popular enough to warrant 
 ### Internal Hosting
 
 We all wish we could use [GitHub] [github]. If you're behind a firewall or in a restrictive environment, though, the public Internet site may not work. 
-Thankfully, [GitHub] [github] offers an [enterprise version](https://enterprise.github.com) that gives you the best of both worlds. [@devnulled's GitHub Enterprise overview](https://github.com/github/teach.github.com/blob/gh-pages/resources/GitHub-Enterprise.md) has lots of good reasons why GitHub Enterprise could benefit your team and organization.
+Thankfully, [GitHub] [github] offers an [enterprise version](https://enterprise.github.com) that gives you the best of both worlds. [@devnulled's GitHub Enterprise overview](http://teach.github.com/articles/github-enterprise-features/) has lots of good reasons why GitHub Enterprise could benefit your team and organization.
 
 Here's a few other options for hosting Git yourself
 


### PR DESCRIPTION
Sorry, found one other link that was amiss (and you closed the other PR too fast). The link to Brandon's usecase (GitHub Enterprise benefits) was broken, I guess after the change to Jekyll/Octopress. I fixed it (but just pointed to the external link, i.e. http://teach.github.com/articles/github-enterprise-features/), maybe there's a better way to link to internal docs?
