### PR TITLE
Backslash escape required for links with parentheses

### DIFF
--- a/classnotes/2012-10-31-git-github-foundations-online.md
+++ b/classnotes/2012-10-31-git-github-foundations-online.md
@@ -33,7 +33,7 @@ Taught by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2012-11-02-nfjs-git-workshop1.md
+++ b/classnotes/2012-11-02-nfjs-git-workshop1.md
@@ -11,7 +11,7 @@ Held on 2012-11-02 and 2012-11-03 and taught by Matthew McCullough ([Twitter](ht
 
 ## Advanced Git Notes
 * [ghi gem](https://github.com/stephencelis/ghi)
-* [hubgem ](https://github.com/defunkt/hub)
+* [hubgem](https://github.com/defunkt/hub)
 * [gist gem](https://github.com/defunkt/gist)
 * [gitg](http://git.gnome.org/browse/gitg) instead of gitk
 * [tig](http://gitready.com/advanced/2009/07/31/tig-the-ncurses-front-end-to-git.html)
@@ -36,7 +36,7 @@ Held on 2012-11-02 and 2012-11-03 and taught by Matthew McCullough ([Twitter](ht
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2012-11-05-git-github-basics-online.md
+++ b/classnotes/2012-11-05-git-github-basics-online.md
@@ -41,7 +41,7 @@ Taught by:
 ## Tools, Tips, Shortcuts
 
 * [ghi gem](https://github.com/stephencelis/ghi)
-* [hubgem ](https://github.com/defunkt/hub)
+* [hubgem](https://github.com/defunkt/hub)
 * [gist gem](https://github.com/defunkt/gist)
 * [gitg](http://git.gnome.org/browse/gitg) instead of gitk
 * [tig](http://gitready.com/advanced/2009/07/31/tig-the-ncurses-front-end-to-git.html)
@@ -67,7 +67,7 @@ Taught by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2012-11-09-wjax-git-workshop.md
+++ b/classnotes/2012-11-09-wjax-git-workshop.md
@@ -50,7 +50,7 @@ https://githubtraining.campfirenow.com/d8903
 ## Tools, Tips, Shortcuts
 
 * [ghi gem](https://github.com/stephencelis/ghi)
-* [hubgem ](https://github.com/defunkt/hub)
+* [hubgem](https://github.com/defunkt/hub)
 * [gist gem](https://github.com/defunkt/gist)
 * [gitg](http://git.gnome.org/browse/gitg) instead of gitk
 * [tig](http://gitready.com/advanced/2009/07/31/tig-the-ncurses-front-end-to-git.html)
@@ -76,7 +76,7 @@ https://githubtraining.campfirenow.com/d8903
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2012-11-12-sandia-online-class.md
+++ b/classnotes/2012-11-12-sandia-online-class.md
@@ -37,7 +37,7 @@ Taught by:
 ## Tools, Tips, Shortcuts
 
 * [ghi gem](https://github.com/stephencelis/ghi)
-* [hubgem ](https://github.com/defunkt/hub)
+* [hubgem](https://github.com/defunkt/hub)
 * [gist gem](https://github.com/defunkt/gist)
 * [gitg](http://git.gnome.org/browse/gitg) instead of gitk
 * [tig](http://gitready.com/advanced/2009/07/31/tig-the-ncurses-front-end-to-git.html)
@@ -63,7 +63,7 @@ Taught by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2012-11-15-git-github-foundations-online.md
+++ b/classnotes/2012-11-15-git-github-foundations-online.md
@@ -32,7 +32,7 @@ Taught by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2012-11-27-rich-web-experience-git-workshop.md
+++ b/classnotes/2012-11-27-rich-web-experience-git-workshop.md
@@ -1,7 +1,7 @@
 ---
 layout: bare
 title: Rich Web Experience Git/GitHub Workshop
-description: An all-dayGit workshop at the Rich Web Experience 2012
+description: An all-day Git workshop at the Rich Web Experience 2012
 tags: [notes, conference, workshop]
 path: classnotes/2012-11-27-rich-web-experience-git-workshop.md
 eventdate: 2012-11-27
@@ -38,7 +38,7 @@ Taught by:
 
 ## Tools, Tips, Shortcuts
 * [ghi gem](https://github.com/stephencelis/ghi)
-* [hubgem ](https://github.com/defunkt/hub)
+* [hubgem](https://github.com/defunkt/hub)
 * [gist gem](https://github.com/defunkt/gist)
 * [gitg](http://git.gnome.org/browse/gitg) instead of gitk
 * [tig](http://gitready.com/advanced/2009/07/31/tig-the-ncurses-front-end-to-git.html)
@@ -68,7 +68,7 @@ Taught by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2012-12-03-denver-git-workshop.md
+++ b/classnotes/2012-12-03-denver-git-workshop.md
@@ -64,7 +64,7 @@ Taught by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2012-12-05-git-github-foundations-online.md
+++ b/classnotes/2012-12-05-git-github-foundations-online.md
@@ -48,7 +48,7 @@ This code was found by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix)
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2012-12-07-seagate-class.md
+++ b/classnotes/2012-12-07-seagate-class.md
@@ -64,7 +64,7 @@ Taught by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2012-12-10-time-warner-wynkoop.md
+++ b/classnotes/2012-12-10-time-warner-wynkoop.md
@@ -66,7 +66,7 @@ Taught by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2012-12-11-time-warner-broomfield.md
+++ b/classnotes/2012-12-11-time-warner-broomfield.md
@@ -38,7 +38,7 @@ Taught by:
 ## Tools, Tips, Shortcuts
 
 * [ghi gem](https://github.com/stephencelis/ghi)
-* [hubgem ](https://github.com/defunkt/hub)
+* [hubgem](https://github.com/defunkt/hub)
 * [gist gem](https://github.com/defunkt/gist)
 * [gitg](http://git.gnome.org/browse/gitg) instead of gitk
 * [tig](http://gitready.com/advanced/2009/07/31/tig-the-ncurses-front-end-to-git.html)
@@ -64,7 +64,7 @@ Taught by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2012-12-11-women-who-code.md
+++ b/classnotes/2012-12-11-women-who-code.md
@@ -65,7 +65,7 @@ Taught by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2013-01-09-chicago-trading-company.md
+++ b/classnotes/2013-01-09-chicago-trading-company.md
@@ -63,7 +63,7 @@ Taught by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2013-01-22-git-github-foundations-online.md
+++ b/classnotes/2013-01-22-git-github-foundations-online.md
@@ -34,7 +34,7 @@ Teachers:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix)
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2013-01-28-ILT-git-foundations.md
+++ b/classnotes/2013-01-28-ILT-git-foundations.md
@@ -17,9 +17,9 @@ eventdate: 2013-01-28
 
 # Helpful Links
 * Git-SCM
-	* [http://www.git-scm.com](http:/www.git-scm.com)
+	* [http://www.git-scm.com](http://www.git-scm.com)
 * Free-Online Git Pro Book
-	* [http://http://git-scm.com/book](http://http://git-scm.com/book)
+	* [http://git-scm.com/book](http://git-scm.com/book)
 * GitHub Free Online Classes
 	* [https://training.github.com/web/free-classes/](https://training.github.com/web/free-classes/)
 * Training Team Q&A

--- a/classnotes/2013-01-29-private-advanced-class.md
+++ b/classnotes/2013-01-29-private-advanced-class.md
@@ -16,7 +16,7 @@ eventdate: 2013-01-29
 * [Hot or Not Slides](http://cl.ly/1z1C410S422a/content)
 * [Workshop Slides](http://cl.ly/1l3d1Z1r3p3b/content)
 * [Cheat Sheets](http://teach.github.com/articles/git-cheatsheets/)
-* [Visual Merge Tools](http://www.youtube.com/watch?v=xfh13LcgqIU&feature=plcp)
+* [Visual Merge Tools](http://www.youtube.com/watch?v=xfh13LcgqIU)
 * [Git & GitHub Public Videos](http://www.youtube.com/github)
 * [Slides](http://teach.github.com/articles/course-slides/)
 * [Slide PDF 1](http://githubtraining.s3.amazonaws.com/github-git-training-slides.pdf)

--- a/classnotes/2013-02-06-online-class.md
+++ b/classnotes/2013-02-06-online-class.md
@@ -33,7 +33,7 @@ Teachers
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix)
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2013-02-07-onlineclassnotes.md
+++ b/classnotes/2013-02-07-onlineclassnotes.md
@@ -49,7 +49,7 @@ Teachers:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix)
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2013-02-08-freegithubwebflowclass.md
+++ b/classnotes/2013-02-08-freegithubwebflowclass.md
@@ -63,7 +63,7 @@ Taught by:
 ## Tools, Tips, Shortcuts
 
 * [ghi gem](https://github.com/stephencelis/ghi)
-* [hubgem ](https://github.com/defunkt/hub)
+* [hubgem](https://github.com/defunkt/hub)
 * [gist gem](https://github.com/defunkt/gist)
 * [gitg](http://git.gnome.org/browse/gitg) instead of gitk
 * [tig](http://gitready.com/advanced/2009/07/31/tig-the-ncurses-front-end-to-git.html)
@@ -89,7 +89,7 @@ Taught by:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2013-02-11-ILT-git-foundations.md
+++ b/classnotes/2013-02-11-ILT-git-foundations.md
@@ -17,9 +17,9 @@ eventdate: 2013-02-11
 
 # Helpful Links
 * Git-SCM
-  * [http://www.git-scm.com](http:/www.git-scm.com)
+  * [http://www.git-scm.com](http://www.git-scm.com)
 * Free-Online Git Pro Book
-	* [http://http://git-scm.com/book](http://http://git-scm.com/book)
+	* [http://git-scm.com/book](http://git-scm.com/book)
 * GitHub Free Online Classes
 	* [https://training.github.com/web/free-classes/](https://training.github.com/web/free-classes/)
 * Training Team Q&A

--- a/classnotes/2013-02-12-ILT-git-foundations.md
+++ b/classnotes/2013-02-12-ILT-git-foundations.md
@@ -17,9 +17,9 @@ eventdate: 2013-02-12
 
 # Helpful Links
 * Git-SCM
-  * [http://www.git-scm.com](http:/www.git-scm.com)
+  * [http://www.git-scm.com](http://www.git-scm.com)
 * Free-Online Git Pro Book
-	* [http://http://git-scm.com/book](http://http://git-scm.com/book)
+	* [http://git-scm.com/book](http://git-scm.com/book)
 * GitHub Free Online Classes
 	* [https://training.github.com/web/free-classes/](https://training.github.com/web/free-classes/)
 * Training Team Q&A

--- a/classnotes/2013-02-18-git-github-foundations-online.md
+++ b/classnotes/2013-02-18-git-github-foundations-online.md
@@ -33,7 +33,7 @@ Teachers:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix)
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2013-02-19-online-git-foundations.md
+++ b/classnotes/2013-02-19-online-git-foundations.md
@@ -17,9 +17,9 @@ eventdate: 2013-02-12
 
 # Helpful Links
 * Git-SCM
-  * [http://www.git-scm.com](http:/www.git-scm.com)
+  * [http://www.git-scm.com](http://www.git-scm.com)
 * Free-Online Git Pro Book
-  * [http://http://git-scm.com/book](http://http://git-scm.com/book)
+  * [http://git-scm.com/book](http://git-scm.com/book)
 * GitHub Free Online Classes
 	* [https://training.github.com/web/free-classes/](https://training.github.com/web/free-classes/)
 * Training Team Q&A

--- a/classnotes/2013-02-21-private-advanced-class.md
+++ b/classnotes/2013-02-21-private-advanced-class.md
@@ -21,7 +21,7 @@ eventdate: 2013-02-21
 * [Ask a Git or GitHub Question](https://github.com/githubtraining/feedback)
 * [Workshop Slides](http://cl.ly/1l3d1Z1r3p3b/content)
 * [Cheat Sheets](http://teach.github.com/articles/git-cheatsheets/)
-* [Visual Merge Tools](http://www.youtube.com/watch?v=xfh13LcgqIU&feature=plcp)
+* [Visual Merge Tools](http://www.youtube.com/watch?v=xfh13LcgqIU)
 * [Git & GitHub Public Videos](http://www.youtube.com/github)
 * [Slides](http://teach.github.com/articles/course-slides/)
 * [Slide PDF 1](http://githubtraining.s3.amazonaws.com/github-git-training-slides.pdf)
@@ -30,7 +30,7 @@ eventdate: 2013-02-21
 
 ## Tools, Tips, Shortcuts
 * [ghi gem](https://github.com/stephencelis/ghi)
-* [hubgem ](https://github.com/defunkt/hub)
+* [hubgem](https://github.com/defunkt/hub)
 * [gist gem](https://github.com/defunkt/gist)
 * [gitg](http://git.gnome.org/browse/gitg) instead of gitk
 * [tig](http://gitready.com/advanced/2009/07/31/tig-the-ncurses-front-end-to-git.html)

--- a/classnotes/2013-02-22-scale11-linux-advanced-class.md
+++ b/classnotes/2013-02-22-scale11-linux-advanced-class.md
@@ -23,7 +23,7 @@ eventdate: 2013-02-22
 * [Ask a Git or GitHub Question](https://github.com/githubtraining/feedback)
 * [Workshop Slides](http://cl.ly/1l3d1Z1r3p3b/content)
 * [Cheat Sheets](http://teach.github.com/articles/git-cheatsheets/)
-* [Visual Merge Tools](http://www.youtube.com/watch?v=xfh13LcgqIU&feature=plcp)
+* [Visual Merge Tools](http://www.youtube.com/watch?v=xfh13LcgqIU)
 * [Git & GitHub Public Videos](http://www.youtube.com/github)
 * [Slides](http://teach.github.com/articles/course-slides/)
 * [Slide PDF 1](http://githubtraining.s3.amazonaws.com/github-git-training-slides.pdf)

--- a/classnotes/2013-02-26-git-github-foundations-online.md
+++ b/classnotes/2013-02-26-git-github-foundations-online.md
@@ -12,7 +12,7 @@ on 2013-02-26 through 2013-02-27
 Teachers:
 
 * Matthew McCullough ([Twitter](http://twitter.com/matthewmccull), [GitHub](https://github.com/matthewmccullough))
-* Matt Yoho ([Twitter](), [GitHub](https://github.com/mattyoho))
+* Matt Yoho ([Twitter](https://twitter.com/mattyoho), [GitHub](https://github.com/mattyoho))
 
 
 ## Resources
@@ -30,7 +30,7 @@ Teachers:
 * [Open Source Git Ignores](https://github.com/github/gitignore)
 * [Ship of Theseus - Related to Similarity Index](http://en.wikipedia.org/wiki/Ship_of_Theseus)
 * [git-p4 Perforce Script](http://kb.perforce.com/article/1417/git-p4)
-* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix))
+* [Unix watch command](http://en.wikipedia.org/wiki/Watch_(Unix\))
 * [SHA-1 Hash Collisions](http://git-scm.com/book/ch6-1.html#A-SHORT-NOTE-ABOUT-SHA-1)
 * [NPD Git Cheatsheet](http://ndpsoftware.com/git-cheatsheet.html)
 * [More Git Cheatsheets](http://teach.github.com/articles/git-cheatsheets/)

--- a/classnotes/2013-02-26-online-git-foundations.md
+++ b/classnotes/2013-02-26-online-git-foundations.md
@@ -17,9 +17,9 @@ eventdate: 2013-02-26
 
 # Helpful Links
 * Git-SCM
-    * [http://www.git-scm.com](http:/www.git-scm.com)
+    * [http://git-scm.com](http://git-scm.com/)
 * Free-Online Git Pro Book
-    * [http://http://git-scm.com/book](http://http://git-scm.com/book)
+    * [http://git-scm.com/book](http://git-scm.com/book)
 * GitHub Free Online Classes
     * [https://training.github.com/web/free-classes/](https://training.github.com/web/free-classes/)
 * Training Team Q&A


### PR DESCRIPTION
Also fixes up some malformed links to Git SCM and Pro Git book sites.

Wasn't sure if you wanted any touch-ups on the transcript portions for the casing or sentence fragments.
