### PR TITLE
Added HydeSlides Plugins submodule for initial T of C feature

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "/Users/jordanm/Documents/Projects/teach.github.com/presentations/dependencies/plugins"]
+	path = /Users/jordanm/Documents/Projects/teach.github.com/presentations/dependencies/plugins
+	url = https://github.com/jordanmccullough/hydeslides-plugins.git

--- a/_includes/hydeslides/revealjs.html
+++ b/_includes/hydeslides/revealjs.html
@@ -24,3 +24,5 @@
 		]
 	});
 </script>
+
+<script src="dependencies/plugins/launcher/launcher.js"></script>


### PR DESCRIPTION
New submodule to OSS HydeSlides Plugins now supplies support for the Table of Contents feature in all teach.github.com/presentations slide decks. 
