### PR TITLE
Corrected submodule path for presentations/, accidental absolute pathing...

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "/Users/jordanm/Documents/Projects/teach.github.com/presentations/dependencies/plugins"]
-	path = /Users/jordanm/Documents/Projects/teach.github.com/presentations/dependencies/plugins
+[submodule "presentations/dependencies/plugins"]
+	path = presentations/dependencies/plugins
 	url = https://github.com/jordanmccullough/hydeslides-plugins.git


### PR DESCRIPTION
Oops. Somehow the submodule path, when setup on the dev box, got absolute and not relative to the teach.github.com/ dir structure. 

`.gitmodules` manually edited to fix, and this should resolve the issue.
