### PR TITLE
Removing duplicate h1 with title

### DIFF
--- a/_layouts/blogpost.html
+++ b/_layouts/blogpost.html
@@ -4,7 +4,6 @@ layout: bare
 
 <div id="page">
   <div id="body">
-    {% if page.title %}<h1>{{ page.title }}</h1>{% endif %}
     {{ content }}
   </div>
 </div>


### PR DESCRIPTION
The bare.html layout file already outputs the page.title as an `<h1>`, so blog posts currently get duplicate titles (see [Refactoring](http://teach.github.com/articles/Refactoring/) or [Materials launched](http://teach.github.com/articles/Materials-Launched/))
