### PR TITLE
transfered outlines from another repo.

### DIFF
--- a/presentations/git-for-publishing.html
+++ b/presentations/git-for-publishing.html
@@ -25,3 +25,47 @@ chapters: [
 	'goodbye']
 categories: ['presentations']
 ---
+
+# GitHub workshop for Publishers and Authors
+
+* Three parts
+* 90 minutes total
+
+# Outline
+
+## Part One: The Tools
+* GitHub web flow
+* Create a repo
+* Add a file
+* Make changes
+* Show rendering of publishing formats (AsciiDoc, Markdown, RsT)
+
+## Part Two: The Process, Collaboration
+* Show collaboration
+* Add a contributor
+* "Simultaneous" commits
+
+# Part Three: Widening the Contribution Net
+* Pull request across forks
+
+# Examples
+Presentation Patterns Example for Git Notes and Jenkins validation of book:
+
+https://github.com/PresentationPatterns/ppap/commit/5d6050c5282dd6eb97075ea4683f6f97876192d5
+
+Article on authoring with GitHub:
+
+http://teach.github.com/articles/book-authoring-using-git-and-github/
+
+
+# Resources
+
+* https://github.com/fperez/reprosw
+* http://nbviewer.ipython.org/urls/raw.github.com/fperez/reprosw/master/Version%20Control.ipynb
+* http://nyuccl.org/pages/GitTutorial/
+* https://github.com/karthikram/smb_git
+* https://docs.google.com/a/github.com/document/d/1zkgcsapeUppq12idnURc7LQrwn3PmRQ5zksrZ7HuRbA/edit
+* http://www.toccon.com/toc2013/public/schedule/detail/26977
+* http://ipython.org/
+* http://readthedocs.org
+

--- a/presentations/git-foundations.html
+++ b/presentations/git-foundations.html
@@ -2,29 +2,228 @@
 layout: hydeslides
 title: GitHub Foundations
 chapters: [
-	'preroll', 
-	'intro',
-	'git',
-	'setup', 
-	'config', 
-	'init', 
-	'git/repository', 
-	'commit', 
-	'diff', 
-	'log', 
-	'rm-mv', 
-	'ignore', 
-	'checkout', 
-	'branch', 
-	'merge', 
-	'rebase', 
-	'network', 
-	'github/intro', 
-	'github/forking', 
-	'github/pull-request',  
-	'reset',
-	'gui',
-	'reflog',
-	'goodbye']
+  'preroll', 
+  'intro',
+  'git',
+  'setup', 
+  'config', 
+  'init', 
+  'git/repository', 
+  'commit', 
+  'diff', 
+  'log', 
+  'rm-mv', 
+  'ignore', 
+  'checkout', 
+  'branch', 
+  'merge', 
+  'rebase', 
+  'network', 
+  'github/intro', 
+  'github/forking', 
+  'github/pull-request',  
+  'reset',
+  'gui',
+  'reflog',
+  'goodbye']
 categories: ['presentations']
 ---
+
+# Git Foundations
+
+
+# Getting Started
+## Intro
+* Git: version control system
+* GitHub: store code, share code
+
+## Preparation
+* Installing git
+* Verifying & checking version
+  * `git --version`
+
+## config
+* 3 tiers of config
+  * `--global`
+  * `--system`
+  * `--local (default)`
+* `git config --list`
+* `git config user.name`
+* `git config user.email`
+* `git config --global core.autocrlf <value>`
+* `git config --global color.ui auto`
+
+
+## commit
+* `git status`
+  * Reviewing help on status output
+* `git add <filename>`
+* `git commit` or `git commit -m"<message>"`
+
+
+## diff
+* `git diff`
+  * Working copy to staging
+* `git diff --staged`
+  * Staged to commit
+* `git diff HEAD`
+  * Working copy to commit
+
+### Decorating diffs
+  * `git diff --color-words`
+  * `git diff --word-diff`
+
+## log
+* `log`
+  * commit history
+* `git log -<n>`
+* `git log --author=<committer>`
+  * Querying for patch author
+* `git log -S=<StringInPatch>`
+  * Search for string match _in_ patch
+* `git log --stat`
+  * Listing files of patch
+* `git log --patch`
+  * Listing patch change sets
+* `git log --word-diff --patch`
+* `git log --graph`
+
+## rm
+* Git interacting with filesystem
+* Removes (deletes!) the file, stages deletion
+  * `git rm <file>`
+
+* Un-tracking tracked files
+  * `git rm --cached -- <filename>`
+
+## mv
+* Moving generates new tree, not a new blob
+  * Hash will be different
+  * `git mv <file> <file>`
+
+### Similarity Index
+* Noting "100%" on commit output?
+  * `git log --stat -M`
+  * `git log --follow <file>`
+
+## ignore
+* Creating a .gitignore
+* Adding patterns
+* Global/external ignore
+  * `git config --global core.excludesfile`
+
+
+## branch
+* Creating feature or prototype
+* Showing local branches
+  * `git branch` 
+* Showing remote branches
+  * `git branch -r`
+* Showing all branches
+  * `git branch -a`
+* Creating a branch
+  * `git branch <name> <ref>`
+* Deleting a branch
+  * `git branch -d <name>`
+
+## merge
+* Folding in branches
+  * `git merge` or `git merge -m<message>`
+* Conflicting merges
+  * Resolving file
+  * `git add <file>`
+  * `git rebase --continue`
+
+
+## rebase
+### branch preparation
+* Explaining fast-forward
+* Rebasing __is not__ merging!
+  * `git checkout <featurebranch>`
+  * `git rebase master`
+
+### interactive
+* `git rebase -i <REF>`
+
+## reflog
+* Tracing Git action "history"
+
+## reset
+* Losing data with Git is difficult (but possible)
+* Clearing index and working directory
+  * `git reset --hard`
+* Reseting index, updating working directory
+  * `git reset --mixed`
+* Reseting index only
+  * `git reset --soft`
+
+## revert
+* Generating commit to restore past patch set
+  * `git revert <REF>`
+
+# GitHub
+
+## Basic Interaction
+* Creating an account
+* Reviewing UI
+* Deciding on protocol
+  * https
+  * ssh
+* Creating a new _repo_
+
+
+## Repo Retrieval
+* Using `git clone`
+* Understanding remotes
+
+## Network
+* `git remote add origin <url>`
+* show how `origin` will be setup
+
+## remote
+* Aliasing to server paths
+  * `git remote add <name> <path>`
+* Removing connections
+  * `git remote -d <name>`
+
+## push
+* Publishing commit history
+  * `git push -u origin master`
+
+## pull
+* Automatically fold-in/merge remote's commits
+  * `git pull origin`
+
+## fetch
+* Comparing without merging
+* Merging selectively
+* Rebasing with respect to published
+  * `git fetch <URL> <branch>`
+  * `FETCH_HEAD`
+
+## Pull Request
+* Pushing branch to repo
+* Creating GH pull request
+
+### Automatic Merge
+* Using GH Interface
+
+### Manual Merge
+* Using `FETCH_HEAD` approach
+* Using GitHub tip approach
+
+
+# Bonus Material
+
+## stash
+* `git stash`
+* `git stash list`
+* `git stash pop <name>`
+* `git stash drop <name>`
+* `git stash apply`
+
+## tag
+* `git tag -m<message>  <NAME>`
+* `git tag -a -m<message> <NAME>`
+* `git tag`
+


### PR DESCRIPTION
Placed the outlines as the "content" for the presentations
they belonged to. This will be the way it works for the time
being until such a time that a better method is available.

/cc @jordanmccullough @matthewmccullough as these are primarily your outlines.

Double checked with the rendering on this, it doesnt effect the (broken) presentation index page nor does it break the presentations themselves.
