### PR TITLE
Revising slide content, notes, titles

### DIFF
--- a/presentations/_posts/branch/0001-01-01-Development-Flexibility.md
+++ b/presentations/_posts/branch/0001-01-01-Development-Flexibility.md
@@ -1,0 +1,10 @@
+---
+chapter: Branch
+layout: slide
+tags: ['branch']
+categories: ['slidecontent']
+---
+
+* Branches are _cheap_
+* Branches are _safe_
+* Branches are _flexible_

--- a/presentations/_posts/checkout/0001-01-01-Purpose-of-Checkout.md
+++ b/presentations/_posts/checkout/0001-01-01-Purpose-of-Checkout.md
@@ -4,9 +4,9 @@ layout: slide
 tags: ['checkout']
 ---
 
-* Aborting Changes
-* Exploring Commits
-* Changing Branches
+* _Aborting_ Changes
+* _Exploring_ Commits
+* _Changing_ Branches
 
 
 {% include hydeslides/notes-open.html %}

--- a/presentations/_posts/checkout/0002-01-01-Checkout-Options.md
+++ b/presentations/_posts/checkout/0002-01-01-Checkout-Options.md
@@ -9,3 +9,9 @@ tags: ['checkout']
 	$ git checkout <branch>
 
 	$ git checkout <REF>
+
+
+{% include hydeslides/notes-open.html %}
+* The power of simple branch toggling
+
+{% include hydeslides/notes-close.html %}

--- a/presentations/_posts/commit/0001-02-01-Shopping-Cart.md
+++ b/presentations/_posts/commit/0001-02-01-Shopping-Cart.md
@@ -5,12 +5,10 @@ tags: ['commit']
 categories: ['slidecontent']
 ---
 
+* Put things in _(stage)_
+* Take things out _(unstage)_
+* Purchase at register _(commit)_
 
-<div class="sticky">
-	<span><i class="icon-shopping-cart"> </i></span>
-
-	commit concept
-</div>
 
 {% include hydeslides/notes-open.html %}
 Shopping Cart


### PR DESCRIPTION
Changes are _not_ PR merge-ready as of first commit, but wanted to open up the review and discussion around the slide deck content.

Goals of this PR and the associated changes:
- Improve the language and consistency across slides
- Tidy up redundant content
- Amp-up the presenter notes and align with class notes/outline

Slide deck optional goals:
- Fix basic order of slides to more gradually build knowledge basic for students
- Resolve topics that are ahead of each other (e.g. `git checkout branch` before `git branch`, etc.)
