### PR TITLE
Removed chapter slide-cover "blackout" style

### DIFF
--- a/presentations/dependencies/themes/cobalt/decorations.scss
+++ b/presentations/dependencies/themes/cobalt/decorations.scss
@@ -1,18 +1,5 @@
 .blackout .reveal .state-background {
-  background: $dark-mnch;
-}
-
-
-.blackout .reveal .state-background::before{
-	content: "";
-  -webkit-mask-box-image: url(backgrounds/blacktocat-2.png) round round;
-  background: $bright-mnch;
-  position: absolute;
-  top: 0;
-  left: 0;
-  opacity: .15;
-  height: 100%;
-  width: 100%;
+  background: none;
 }
 
 

--- a/presentations/dependencies/themes/cobalt/elements.scss
+++ b/presentations/dependencies/themes/cobalt/elements.scss
@@ -42,10 +42,13 @@ body {
 .reveal h1 {
   font-family: $font-title;
   font-size: 3em;
+  margin: auto auto .5em auto;
   letter-spacing: -.05em;
   color: $bright-mnch;
-  text-shadow: 2px 2px 3px $dark-mnch, -1px 2px 0 $mnch-light, 0 3px 0 $mnch-medium, 0 2px 0 $mnch-light;
+  text-shadow: 2px 2px 3px $dark-mnch;
 }
+
+
 .reveal h2{
   font-size: 1.8em;
   font-family: $font-title;

--- a/presentations/dependencies/themes/cobalt/theme.css
+++ b/presentations/dependencies/themes/cobalt/theme.css
@@ -64,18 +64,7 @@ code, em {
 */
 /* No HydeSlides layouts defined yet */
 .blackout .reveal .state-background {
-  background: #2b2c25; }
-
-.blackout .reveal .state-background::before {
-  content: "";
-  -webkit-mask-box-image: url(backgrounds/blacktocat-2.png) round round;
-  background: #eeeeee;
-  position: absolute;
-  top: 0;
-  left: 0;
-  opacity: .15;
-  height: 100%;
-  width: 100%; }
+  background: none; }
 
 .reveal .brand {
   background: url(branding/github_logo_social_coding.png) no-repeat center;
@@ -200,9 +189,10 @@ body {
 .reveal h1 {
   font-family: "Montserrat Alternates", sans-serif;
   font-size: 3em;
+  margin: auto auto 0.5em auto;
   letter-spacing: -.05em;
   color: #eeeeee;
-  text-shadow: 2px 2px 3px #2b2c25, -1px 2px 0 #e1e1e1, 0 3px 0 #333333, 0 2px 0 #e1e1e1; }
+  text-shadow: 2px 2px 3px #2b2c25; }
 
 .reveal h2 {
   font-size: 1.8em;


### PR DESCRIPTION
Due to performance issues with CSS3 transforms, the Octocat chapter cover slide styling has been simplified.
![Screen Shot 2013-03-21 at 5 13 32 PM](https://f.cloud.github.com/assets/352082/288622/1f9de64a-927d-11e2-9842-e63695e9773e.png)
