### PR TITLE
Pre-roll slide editable for chat link

### DIFF
--- a/presentations/_posts/preroll/0001-01-01-Preroll.md
+++ b/presentations/_posts/preroll/0001-01-01-Preroll.md
@@ -8,12 +8,14 @@ categories: ['slidecontent']
 ---
 
 ## Classroom Chat
-[githubtraining.campfirenow.com/---](https://githubtraining.campfirenow.com/---)
+<div class="pseudoLink" contenteditable>githubtraining.campfirenow.com/---</div>
 
-## Office Hours
+---
+
+### Office Hours
 [training.github.com/web/free-classes/](https://training.github.com/web/free-classes/)
 
-## Training Team Q&A
+### Training Team Q&A
 [github.com/githubtraining/feedback](githubtraining/feedback/)
 
 {% include hydeslides/notes-open.html %}

--- a/presentations/dependencies/themes/cobalt/elements.scss
+++ b/presentations/dependencies/themes/cobalt/elements.scss
@@ -34,7 +34,7 @@ body {
 .reveal h4,
 .reveal h5,
 .reveal h6 {
-  margin: 0 0 0 0;
+  margin: .5em 0 0 0;
   line-height: 0.9em;
   text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2);
 }
@@ -56,7 +56,7 @@ body {
 
 .reveal h3{
   font-size: 1.2em;
-  color: $mnch-medium;
+  color: $bright-color;
   font-weight: normal;
 }
 
@@ -73,7 +73,7 @@ body {
   transition: color .15s ease;
 }
 
-.reveal a:not(.image):hover {
+.reveal a:not(.image):hover, .pseudoLink {
   color: $bright-mnch;
   text-shadow: none;
   border: none;

--- a/presentations/dependencies/themes/cobalt/theme.css
+++ b/presentations/dependencies/themes/cobalt/theme.css
@@ -193,7 +193,7 @@ body {
 .reveal h4,
 .reveal h5,
 .reveal h6 {
-  margin: 0 0 0 0;
+  margin: 0.5em 0 0 0;
   line-height: 0.9em;
   text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2); }
 
@@ -213,7 +213,7 @@ body {
 
 .reveal h3 {
   font-size: 1.2em;
-  color: #333333;
+  color: #1aafec;
   font-weight: normal; }
 
 /*********************************************
@@ -228,7 +228,7 @@ body {
   -o-transition: color 0.15s ease;
   transition: color 0.15s ease; }
 
-.reveal a:not(.image):hover {
+.reveal a:not(.image):hover, .pseudoLink {
   color: #eeeeee;
   text-shadow: none;
   border: none; }


### PR DESCRIPTION
Eliminates need for editing Markdown file on-the-fly for changing chat link in pre-roll slide. Text styled as a hyperlink, editable in-browser for quick updating.

Screenshot:
![Screen Shot 2013-03-24 at 11 29 17 AM](https://f.cloud.github.com/assets/352082/295677/5ec03742-94a8-11e2-927d-85c099e3f6b8.png)
