### PR TITLE
Slidedeck theme fixes

### DIFF
--- a/_includes/hydeslides/revealjs.html
+++ b/_includes/hydeslides/revealjs.html
@@ -4,7 +4,7 @@
 	// Full list of configuration options available here:
 	// https://github.com/hakimel/reveal.js#configuration
 	Reveal.initialize({
-		controls: true,
+		controls: false,
 		progress: true,
 		history: true,
 		center: true,

--- a/presentations/dependencies/themes/cobalt/decorations.scss
+++ b/presentations/dependencies/themes/cobalt/decorations.scss
@@ -41,7 +41,7 @@
 	box-shadow: 1px 1px .09em $mnch-dark, 0px -1px .15em $mnch-light, inset 0 0 3em $sticky-medium;
 	border-radius: 5em 10em .25em 1.5em / 0.25em 0.25em 1em .25em;
 
-	width: 50%;
+	width: 80%;
 	margin: 0 auto;
 	padding: 1em 1em 1em 1em;
 

--- a/presentations/dependencies/themes/cobalt/elements.scss
+++ b/presentations/dependencies/themes/cobalt/elements.scss
@@ -93,6 +93,12 @@ body {
 .reveal section img {
   padding: 0px;
   background: $bright-mnch;
+  
+  padding: .25em;
+  margin: -.25em auto auto -.25em;
+
+  border-radius: .25em;
+
   /*-webkit-transition: all .2s linear;
   -moz-transition: all .2s linear;
   -ms-transition: all .2s linear;

--- a/presentations/dependencies/themes/cobalt/theme.css
+++ b/presentations/dependencies/themes/cobalt/theme.css
@@ -99,7 +99,7 @@ code, em {
   background: #fffab4;
   box-shadow: 1px 1px 0.09em #232322, 0px -1px 0.15em #e1e1e1, inset 0 0 3em #e5cd62;
   border-radius: 5em 10em 0.25em 1.5em/0.25em 0.25em 1em 0.25em;
-  width: 50%;
+  width: 80%;
   margin: 0 auto;
   padding: 1em 1em 1em 1em;
   background: #fefcea;
@@ -233,6 +233,9 @@ body {
 .reveal section img {
   padding: 0px;
   background: #eeeeee;
+  padding: .25em;
+  margin: -0.25em auto auto -0.25em;
+  border-radius: .25em;
   /*-webkit-transition: all .2s linear;
   -moz-transition: all .2s linear;
   -ms-transition: all .2s linear;

--- a/presentations/dependencies/themes/original/elements.scss
+++ b/presentations/dependencies/themes/original/elements.scss
@@ -24,9 +24,7 @@ body {
 }
 
 .reveal section img.diagram{
- /* No Op*/
- border: none;
- box-shadow: none;
+
 }
 
 


### PR DESCRIPTION
Resolves content overflow/hiding on too-small of sticky note elements.
Updates the default RevealJS display of up-down-left-right control arrows (obscures content/distracts when teaching from slide deck)
