### PR TITLE
Fix broken links in preroll

### DIFF
--- a/presentations/_posts/foundations/preroll/0001-01-01-Preroll.md
+++ b/presentations/_posts/foundations/preroll/0001-01-01-Preroll.md
@@ -12,10 +12,10 @@ tags: ['preroll']
 ---
 
 ### Office Hours
-[training.github.com/web/free-classes/](https://training.github.com/web/free-classes/)
+[training.github.com/web/free-classes/](http://training.github.com/web/free-classes/)
 
 ### Training Team Q&A
-[github.com/githubtraining/feedback](githubtraining/feedback/)
+[training.github.com/contact/](http://training.github.com/contact/)
 
 {% capture notes %}
 


### PR DESCRIPTION
Discovered a couple of broken links at http://teach.github.com/presentations/git-foundations.html; this points them to (what I think are) the right locations.
