### PR TITLE
Correct pre-roll slide training team link

### DIFF
--- a/presentations/_posts/foundations/preroll/0001-01-01-Preroll.md
+++ b/presentations/_posts/foundations/preroll/0001-01-01-Preroll.md
@@ -15,7 +15,7 @@ tags: ['preroll']
 [training.github.com/web/free-classes/](http://training.github.com/web/free-classes/)
 
 ### Training Team Q&A
-[training.github.com/contact/](http://training.github.com/contact/)
+[github.com/githubtraining/feedback](http://github.com/githubtraining/feedback/)
 
 {% capture notes %}
 


### PR DESCRIPTION
The contact link and URL for Training Team
contact should point to the feedback repo
to encourage students and participants to
post to the issues area.
