### PR TITLE
Expand out URLs truncated from Campfire exports

### DIFF
--- a/classnotes/2012-06-13-geekout-estonia-advancedgit.md
+++ b/classnotes/2012-06-13-geekout-estonia-advancedgit.md
@@ -20,7 +20,7 @@ eventdate: 2012-06-13
     
 ## Chat Transcript
 
-    Juri H. (possible) Mercurial analog of cherry-pick: http://mercurial.selenic.com/wiki/Transpla…
+    Juri H. (possible) Mercurial analog of cherry-pick: http://mercurial.selenic.com/wiki/TransplantExtension
 
     arhan   So the -x is no use if the cherry-picked commit hash is only in the commit message and not in the metadata? no automated way to track the trail?
     Toomas R.   I understood that -x was to show us more info
@@ -48,11 +48,11 @@ eventdate: 2012-06-13
     Toomas R.   squash - http://et.wikipedia.org/wiki/Squash
     arhan   View paste 
     for mercurial:
-    http://mercurial.selenic.com/wiki/Collapse…
+    http://mercurial.selenic.com/wiki/CollapseExtension
     and http://mercurial.selenic.com/wiki/RebaseExtension
     matthewmccullough   http://git-scm.com/2011/07/11/reset.html
     grd http://www.wikivs.com/wiki/Git_vs_Mercurial
-    matthewmccullough   https://github.com/matthewmccullough/filte…
+    matthewmccullough   https://github.com/matthewmccullough/filter-branch-sample
     View paste 
     https://github.com/matthewmccullough/filter-branch-sample
     Toomas R.   I guess I missed how he got rid of the ISO file, filtered out that directory/file?
@@ -74,16 +74,16 @@ eventdate: 2012-06-13
     https://gist.github.com/2732679
     http://hg-git.github.com/
     Neeme P.    http://www.git-tower.com/
-    matthewmccullough   https://github.com/matthewmccullough/git-w…
+    matthewmccullough   https://github.com/github/teach.github.com
     Juri T. https://github.com/offbytwo/git-hg ? git client -> hg server
-    Neeme P.    http://stackoverflow.com/questions/883452/…
+    Neeme P.    http://stackoverflow.com/questions/883452/git-interoperability-with-a-mercurial-repository
     Ervin   View paste 
     https://github.com/grosser/git-autobisect
     git-autobisect.sh your_unit_test_here
     matthewmccullough   sparse checkout
     git clone --depth
     matthewmccullough   graph depth
-    Michael H.  If you haven't seen it: http://tom.preston-werner.com/2009/05/19/t… nice read
+    Michael H.  If you haven't seen it: http://tom.preston-werner.com/2009/05/19/the-git-parable.html nice read
     matthewmccullough   git log --author --not --since
     matthewmccullough   caret spec for branch paths
     matthewmccullough   git show HEAD~5^2~5

--- a/classnotes/2012-11-09-wjax-git-workshop.md
+++ b/classnotes/2012-11-09-wjax-git-workshop.md
@@ -386,4 +386,4 @@ https://githubtraining.campfirenow.com/d8903
     
     rerere = reuse recorded resolution
     
-    git svn clone --stdlayout http://ambientideas.unfuddle.com/svn/ambie… hgwsub
+    git svn clone --stdlayout http://ambientideas.unfuddle.com/svn/ambientideas_sample11-svnscm/trunk hgwsub

--- a/classnotes/2013-02-07-onlineclassnotes.md
+++ b/classnotes/2013-02-07-onlineclassnotes.md
@@ -584,7 +584,7 @@ Teachers:
     nothing added to commit but untracked files present (use "git add" to track)
     how do we make it ignore "hidden" files
     Tim B.  i_yahoo: Ooooh, the hated .DS_Store! I'll bring this up out loud.
-    Edgar W.    http://superuser.com/questions/272465/using-mul... -- note on how to configure separate ssh keys for "work" (Yahoo!) and non-work (github.com) keys
+    Edgar W.    http://superuser.com/questions/272465/using-multiple-ssh-public-keys -- note on how to configure separate ssh keys for "work" (Yahoo!) and non-work (github.com) keys
     Just for the record
     vishvesh    how to list modified and stage files in project?
     Tim B.  Edgar: Thanks! Was gonna ask you to post that question in https://github.com/githubtraining/feedback/issues, so we could get a decent answer written up for posterity.
@@ -609,7 +609,7 @@ Teachers:
     wanlin p.   what's that gui
     9:30 AM
     Tim B.  wanlin: GitHub for Mac (https://mac.github.com)
-    Greg, Ollie: Some merge/diff tool config here: http://teach.github.com/articles/lesson-git-mer...
+    Greg, Ollie: Some merge/diff tool config here: http://teach.github.com/articles/lesson-git-merge-tool/
     Greg    Ollie - yeah, "git difftool" works instead of "git diff"
     Ollie R.    thanks!
     this is a refresher course for me, but I'm already getting some great new info. I love the technical explanations of what's under the hood, and that add -p is a great tip
@@ -772,9 +772,9 @@ Teachers:
     11:00 AM
     Chiru   can we have the notes/presentation?
     Tim B.  https://github.com/github/trainingteam/issues
-    matthewmccullough   http://teach.github.com/presentations/git-found...
+    matthewmccullough   http://teach.github.com/presentations/git-foundations.html
     Hang S. thank you very much, Matthew and Tim!
-    matthewmccullough   Slides: http://teach.github.com/presentations/git-found...
+    matthewmccullough   Slides: http://teach.github.com/presentations/git-foundations.html
     Edgar W.    Let's you have a separate ssh key for github.com while your Yahoo! ssh key is the default (id_rsa).
     Chiru   thanks guys!
     gully   thanks Edgar
@@ -838,7 +838,7 @@ Teachers:
     tlberglund  wanlin: It looked like "git push -u origin master"
     wanlin: But first, you need "git remote add origin <your github repo url>"
     wanlin p.   I also couldn't get the slides from the link you provided
-    tlberglund  wanlin: http://teach.github.com/presentations/git-found...
+    tlberglund  wanlin: http://teach.github.com/presentations/git-foundations.html
     wanlin p.   thanks
     tlberglund  wanlin: If I type your name as wanline, please forgive me. I keep adding the E, then backspacing. At some point I will forget to backspace. :)
     8:25 AM

--- a/classnotes/2013-02-18-git-github-foundations-online.md
+++ b/classnotes/2013-02-18-git-github-foundations-online.md
@@ -786,17 +786,17 @@ Teachers:
     any specific thing to do to get help ?
     himanshu    thanks
     Aveek M.    is it possible to get the diff in such a way as to know its a diff between a tab and 4 spaces? So I want to know which line in the diff is 4 spaces and which one is a tab. Helpful during code review :-)
-    John B. balac: good question. first, check out: http://www.kernel.org/pub/software/scm/git/docs...
+    John B. balac: good question. first, check out: https://www.kernel.org/pub/software/scm/git/docs/git-diff.html
     balac: I'm not exactly sure why you don't have help installed... what OS are you on?
     Nicolas S.  Aveek: absolutely! I just don't remember exactly how you do that, give me a second :)
     balac   View paste 
     rhel  5.4 (Tikanga)
     9:00 PM
     Jack C. oh yeah LOG!
-    Nicolas S.  Aveek: http://stackoverflow.com/questions/5574195/make...
+    Nicolas S.  Aveek: http://stackoverflow.com/questions/5574195/make-git-highlight-tab-characters-in-a-diff
     that has a very comprehensive answer :)
     John B. balac: seems that you don't have the man pages installed
-    http://stackoverflow.com/questions/14250505/ins...
+    http://stackoverflow.com/questions/14250505/installing-git-documentation-packages-on-rhel-5
     Aveek M.    thx!
     John B. ^ that has some info on installing the man pages for your operating system
     balac   thx.. will check it out later.
@@ -1272,7 +1272,7 @@ Teachers:
     Jack C. bye~
     tlberglund  Jignesh: That would be a great question for the feedback repo! Let me get you that URL.
     Nicolas S.  Jignesh: you can add the repo you forked from as a second remote
-    tlberglund  https://github.com/githubtraining/feedback/issu...
+    tlberglund  https://github.com/githubtraining/feedback/issues
     Nicolas S.  …or, Tim can handle that :)
     tlberglund  Heh.
     Well, Nicolas was giving you the answer. You add, in this case, https://github.com/githubtrainer/poetry.git as a second remote. Maybe call it "upstream" or something.

--- a/classnotes/2013-02-26-git-github-foundations-online.md
+++ b/classnotes/2013-02-26-git-github-foundations-online.md
@@ -556,7 +556,7 @@ Teachers:
     Matt Y.             Thanks, Jeff, see you tomorrow.
     Alejandro G.        bye Jeff
                         thx
-    matthewmccullough   https://github.com/githubteacher/hellogitworld/...
+    matthewmccullough   https://github.com/githubteacher/hellogitworld
     Matt Y.             So, Pull Requests can be made betweens forks of a repo OR within the same repo.
     Matt Y.             Branches are used often in git because they're so lightweight and make it easy using GitHub
                         in particular to review changes collaboratively.
@@ -711,17 +711,17 @@ Teachers:
 
 ## Day Two Chat
 
-    matthewmccullough   Class notes are ready at: http://teach.github.com/classnotes/2013-02-26-g...
+    matthewmccullough   Class notes are ready at: http://teach.github.com/classnotes/2013-02-26-git-github-foundations-online.html
     And will be expanded after class today.
     matthewmccullough   Morning Matt Yoho! Glad to have you here again helping us.
     Matt Y. Good morning!
-    matthewmccullough   Class notes are all ready: http://teach.github.com/classnotes/2013-02-26-g...
+    matthewmccullough   Class notes are all ready: http://teach.github.com/classnotes/2013-02-26-git-github-foundations-online.html
     More will be added at the end of class today, but that's the canonical link.
     Jim A.  on a pull request- what if there are conflicts?
     Matt Y. Jim: If there are conflicts on a pull request, they will have to be resolved manually locally first, then have the merge commit that resolves them pushed up to the Pull Request branch.
     Matt Y. The PR will then apply cleanly and can be closed through the GitHub UI. But in practice those conflicts are relatively infrequent.
     Jim A.  thx
-    matthewmccullough   Class notes are ready: http://teach.github.com/classnotes/2013-02-26-g...
+    matthewmccullough   Class notes are ready: http://teach.github.com/classnotes/2013-02-26-git-github-foundations-online.html
     AL  Had to go into .git/config and change http to https to reset password to use HTTPS to push? Any ideas why?
     Bill    Thanks.
     Rajesh P.   Hello
@@ -731,7 +731,7 @@ Teachers:
     Justin C.   Will there be any information about deployment?
     matthewmccullough   http://training.github.com/web/git-foundations/
     Ilya    were any notes emailed yesterday? i haven't received anything
-    Matt Y. Course notes for yesterday and today: http://teach.github.com/classnotes/2013-02-26-g...
+    Matt Y. Course notes for yesterday and today: http://teach.github.com/classnotes/2013-02-26-git-github-foundations-online.html
     Ilya    thank you
     Matt Y. Np!
     Daniel K.   Do you have a transcription of yesterday's chat?
@@ -1031,13 +1031,13 @@ Teachers:
     Dan how about both? :)
     Daniel K.   I meant, can you "svn checkout" from any git repo, or only from a GitHub repo?
     Bill    Thank you for all the hard work in preparing and delivering this class. Very much appreciated.
-    Matt Y. Cheri: Here's a helpful article on SVN => git conversion https://help.github.com/articles/importing-from...
+    Matt Y. Cheri: Here's a helpful article on SVN => git conversion https://help.github.com/articles/importing-from-subversion
     Bill: On behalf of Matthew, thank you, and thanks for participating.
     Nazila N.   Thank you very much to both of you.
     Jim A.  thx guys!
     Wouter K.   Thanks, great info! See you for the advanced class.
     Matt Y. Daniel: Oh, my mistake. Yes, that's a GitHub feature. It may be replicated elsewhere but isn't standard.
-    matthewmccullough   http://teach.github.com/classnotes/2013-02-26-g...
+    matthewmccullough   http://teach.github.com/classnotes/2013-02-26-git-github-foundations-online.html
     Richard S.  much thanks. Matthew and Matt!
     Justin C.   Thanks!
     Matt Y. Thanks everyone, enjoy your day!

--- a/classnotes/2013-03-14-online-git-foundations.md
+++ b/classnotes/2013-03-14-online-git-foundations.md
@@ -374,7 +374,7 @@ Teachers:
                         https://code.google.com/p/msysgit/downloads/list, let me know
                         be sure to go to https://github.com/signup/free and signup for tomorrow for some 
                         work over the network!
-    matthewmccullough   http://teach.github.com/presentations/git-found...
+    matthewmccullough   http://teach.github.com/presentations/git-foundations.html
     Michael A.          I'm on Windows (sadly), and downloaded from the GitHub installation 
                         instructions. Version 1.8.1.msysgit.1.
     brntbeer            perfect. let me know if you have any other windows questions michael and i'll do 
@@ -390,7 +390,7 @@ Teachers:
                         `git config user.name "YOUR NAME" ` sets it to whatever is in the quotes there
     HariDara            Yes, that is our enterprise install.
     Srividhya A.        Michael Alderete: I'm also on Windows in SFDC netowrk and was able to dowload 
-                        Git 1.8.1 from this link:https://code.google.com/p/msysgit/download... 
+                        Git 1.8.1 from this link:http://code.google.com/p/msysgit/downloads/list 
                         :Git-1.8.1.2-preview20130201.exe
     brntbeer            gotcha. We will get to using remotes more-so tomorrow, but for the sake of the 
                         class we will be using github.com as our remote. The interfaces and 
@@ -436,7 +436,7 @@ Teachers:
                         else elses projects or machines. Later we'll be interacting with an upstream 
                         repo (github.com for the sake of this class)
                         Hi michael! just a happy little note from git there. take a look at 
-                        http://teach.github.com/presentations/git-found... to get an idea of what 
+                        http://teach.github.com/presentations/git-foundations.html#/4/ to get an idea of what 
                         config we generally like setting
     HariDara            What does "6 insertions" mean?
     brntbeer            what we generally like setting for windows machines i mean. this makes line 
@@ -629,7 +629,8 @@ Teachers:
                         you. I'll be looking into it though! love the feedback
                         Michael Alderete: you could try setting the core.editor and that may help you 
                         out here by setting something like instructed here: 
-                        http://stackoverflow.com/questions/10564/how-ca... for making a given window 
+                        http://stackoverflow.com/questions/10564/setup-editor-to-work-with-git-on-windows 
+						for making a given window 
     Michael A.          I wonder if it's not also related to the auto-update feature of GitHub for 
                         Windows? I ran through the whole installation a few weeks ago, and thought I 
                         was good-to-go. But maybe a component got updated, and now doesn't pass the 
@@ -722,7 +723,7 @@ Teachers:
     HariDara            np
     Alicia              Never mind, found it under "public activity" on other users
     brntbeer            Alicia: definitely. works with usernames: 
-                        https://github.com/github/Akavache/commits/mast... for example
+                        https://github.com/github/Akavache/commits?author=xpaulbettsx for example
     brntbeer            Kshama Thacker: Not sure i follow. the reset is going to move us to a previous 
                         version of the project. so if you reset to a point where an ignore wasnt 
                         created, then it wont exist there to be read
@@ -738,7 +739,7 @@ Teachers:
     brntbeer            yep!
     Henry Q.            can't see what you are typing?
     Henry Q.            thanks
-    brntbeer            http://teach.github.com/presentations/git-found... is the slide he's on
+    brntbeer            http://teach.github.com/presentations/git-foundations.html#/8 is the slide he's on
     matthewmccullough   https://github.com/githubtraining/hellogitworld
     brntbeer            Before typing this "clone" command, ensure you're in some sort of scratch 
                         directory, not within the `newproject` file
@@ -773,7 +774,7 @@ Teachers:
                         want to make to that repository
     brntbeer            "ive made some changes to this project on my Fork that i dont have commit access 
                         to, would you please accept these?"
-    matthewmccullough   https://github.com/githubteacher/hellogitworld/...
+    matthewmccullough   https://github.com/githubteacher/hellogitworld/
     brntbeer            Amy: be sure when sending that pull request that we change the "base repo" 
                         dropdown to be "githubteacher"
                         Just got a notification of your pullrequest over to the githubtraining repo :)
@@ -785,7 +786,7 @@ Teachers:
     brntbeer            Amy: awesome. glad to hear (and see!) that you got this fixed
                         Vivek: definitely. you can see at the bottom of your pull-request that there's a 
                         "notification" icon saying that you're watching the thread
-    matthewmccullough   http://teach.github.com/classnotes/2013-03-14-o...
+    matthewmccullough   http://teach.github.com/classnotes/2013-03-14-online-git-foundations.html
     Amy                 update to git version 1.8.1.5 now. Thanks Brian!
     brntbeer            poll window up in go-to-training
                         Thanks for the amazing questions guys! Enjoyed the teaching so far! looking 
@@ -1120,7 +1121,7 @@ Teachers:
     Kshama T.           I see
     Brian S.            so we can have multiple remotes, but only one that will be used by default if i 
                         just say "git push", right?
-    matthewmccullough   https://github.com/githubteacher/hellogitworld/...
+    matthewmccullough   https://github.com/githubteacher/hellogitworld
     Kshama T.           I still can't find my branch on github
     Brian S.            sure
     brntbeer            Henry: i noticed you pushed to master, did you create your featurebranch and 
@@ -1384,7 +1385,7 @@ Teachers:
     HariDara            ok, back up. I had to disconnect my vpn :)
     brntbeer            woot!~ awesome
                         if you're following along, we're on 
-                        http://teach.github.com/presentations/git-found... and 
+                        http://teach.github.com/presentations/git-foundations.html and 
                         with a whole new slide theme that just got updated =)
     Brian S.            so if i do git log on master after fast forward merge, i see each commit from 
                         the branch?
@@ -1430,7 +1431,7 @@ Teachers:
                         them, then we can look at the changes, decide if we want it, and if we dont, we 
                         could tyoe `git merge --abort`
                         Brian St.Clair: it can create a commit. thats when there isnt a FF merge
-                        like shown here: http://teach.github.com/presentations/git-found...
+                        like shown here: http://teach.github.com/presentations/git-foundations.html
                         there's changes on both branches from the point of the split
                         so to pull things together we cant just show things fast forward
     Kshama T.           does reflog/reset work only cumulatively?
@@ -1569,7 +1570,7 @@ Teachers:
     brntbeer            Rejoin foundation online classes at for free at training@github.com
     Brian S.            Thank you guys!
     Oleg                Thank you both - great class!
-    brntbeer            Kshama Thacker: http://teach.github.com/classnotes/2013-03-14-o...
+    brntbeer            Kshama Thacker: http://teach.github.com/classnotes/2013-03-14-online-git-foundations.html
     Joe H.              Yep, very helpful, thanks.
     brntbeer            thank you guys! a real pleasure to teach
     Alicia              re: branching...when would you do a rebase?

--- a/classnotes/2013-03-18-online-foundations-class.md
+++ b/classnotes/2013-03-18-online-foundations-class.md
@@ -625,7 +625,7 @@ eventdate: 2013-03-18
 	Larry K.	has entered the room
 	Jeff O.	awesome! stripping ASCII 19 is an annoyance for me in Linux
 	8:25 PM
-	ben	If you want a longer read on line endings, here's the full story: https://help.github.com/articles/dealing-with-l...
+	ben	If you want a longer read on line endings, here's the full story: https://help.github.com/articles/dealing-with-line-endings
 	ares	git config --global core.autocrlf input
 	Jeff O.	can git be told to strip 'smart quotes' and other Microsoft chars?
 	ben	There's a way to do that, but it's not easy. :)
@@ -635,7 +635,7 @@ eventdate: 2013-03-18
 	ben	What tim said. Did that help?
 	8:30 PM
 	Jeff H.	has entered the room
-	ben	Jeff O: here's the feature you'd use (clean and smudge filters). http://git-scm.com/book/ch7-2.html#Keyword-Expa...
+	ben	Jeff O: here's the feature you'd use (clean and smudge filters). http://git-scm.com/book/en/Customizing-Git-Git-Attributes#Keyword-Expansion
 	Jeff O.	thanks!
 	ben	It's not easy to set up, and it's even harder to share with the whole team, but it *is* possible.
 	Good luck!
@@ -647,7 +647,7 @@ eventdate: 2013-03-18
 	beckie	has entered the room
 	Jeff O.	what is the "[master <hexadecimal>]" message on commit?
 	8:45 PM
-	tlberglund	http://teach.github.com/presentations/git-found...
+	tlberglund	http://teach.github.com/presentations/git-foundations.html#/7
 	ben	NO TRAVELING TO THE FUTURE
 	Jeff O.	ben: if you do, add THEN commit
 	srinivas	has entered the room
@@ -716,7 +716,7 @@ eventdate: 2013-03-18
 	Jeff O.	this .gitignore will be very useful for keeping our package builds out of the repo
 	ben	Yeah, it makes it so your "git status" only shows stuff you care about.
 	10:15 PM
-	Jeff H.	extra info:(local ignore) http://stackoverflow.com/questions/1753070/git-...
+	Jeff H.	extra info:(local ignore) http://stackoverflow.com/questions/1753070/git-ignore-files-only-locally
 	ben	Yeah, .gitignore lives alongside your source files. If you want to ignore stuff *only on your machine*, use info/exclude.
 	10:20 PM
 	wcpan	has left the room

--- a/classnotes/2013-03-21-private-online-class.md
+++ b/classnotes/2013-03-21-private-online-class.md
@@ -925,7 +925,7 @@ eventdate: 2013-03-21
 	;)
 	Jennifer D.	:)
 	Adam B.	thanks jennifer d
-	Jens J.	for Jeff B.: nice answer: http://stackoverflow.com/questions/9392365/how-...
+	Jens J.	for Jeff B.: nice answer: http://stackoverflow.com/questions/9392365/handle-a-sha-1-collision-on-a-blob
 	Jeff B.	to Jens: thanks
 	tlberglund	git log --patch
 	9:20 AM
@@ -1045,7 +1045,7 @@ eventdate: 2013-03-21
 	Lambert M.	has entered the room
 	Tony H.	yesterday there was a link to the presentation materials. could you show us that link again?
 	Jennifer D.	Jennifer S .. I think they said towards the end of today
-	tlberglund	http://teach.github.com/presentations/git-found...
+	tlberglund	http://teach.github.com/presentations/git-foundations.html
 	Vivek P.	has entered the room
 	Jennifer S.	yes, got it, thanks,
 	8:05 AM
@@ -1093,7 +1093,7 @@ eventdate: 2013-03-21
 	8:15 AM
 	aspires	Chuck S. Git comes with color configuration out of the box.
 	I don't know if that what Tim has right now, but it appears so.
-	http://git-scm.com/book/en/Customizing-Git-Git-... for more info
+	http://git-scm.com/book/en/Customizing-Git-Git-Configuration#Colors-in-Git for more info
 	Vivek P.	can you repeat that again
 	Jens J.	i was just keeping quiet
 	tlberglund	Jens: :)
@@ -1204,7 +1204,7 @@ eventdate: 2013-03-21
 	ssh-keygen -f ~/.ssh/github-class
 	Christopher S.	why not move the file?
 	tlberglund	cat ~/.ssh/github-class.pub
-	Jennifer D.	the guide if you are lost .. https://help.github.com/articles/generating-ssh...
+	Jennifer D.	the guide if you are lost .. https://help.github.com/articles/generating-ssh-keys
 	aspires	github.com/settings/ssh
 	9:45 AM
 	Ann R.	has entered the room

--- a/classnotes/2013-03-29-online-foundations-class.md
+++ b/classnotes/2013-03-29-online-foundations-class.md
@@ -61,7 +61,7 @@ eventdate: 2013-03-29
     8:00 AM
     brntbeer    Hi everyone! If anyone has any questions they want to bring up in the chatroom, let me know!
     PHANIDHAR K.    has entered the room
-    brntbeer    http://teach.github.com/presentations/git-found... for anyone wanting to follow along
+    brntbeer    http://teach.github.com/presentations/git-foundations.html for anyone wanting to follow along
     https://github.com/signup/free
     matthewmccullough   http://mac.github.com
     GUI Only
@@ -195,7 +195,7 @@ eventdate: 2013-03-29
     brntbeer    We clicked fork on the teacher's project, which created a copy to our username that we can edit. made the edit, and then clicked "pull request" to propose this change back to the teacher
     Jeff Clark: one at a time, certainly
     10:35 AM
-    matthewmccullough   https://github.com/githubteacher/hellogitworld/...
+    matthewmccullough   https://github.com/githubteacher/hellogitworld/pulls
     Jeff C. Now - but our forks are now obsolete?
     10:40 AM
     brntbeer    Jeff Clark: we'll definitely be showing how to keep your fork up to date! this may happen tomorrow or here in the next 20 minutes. but easily doable
@@ -244,11 +244,11 @@ eventdate: 2013-03-29
     11:00 AM
     brntbeer    Old Town Creative: we'll be showing more branching tomorrow for sure.
     Tom W.  my repository was private, but I wanted to make it public
-    matthewmccullough   https://help.github.com/articles/remove-sensiti...
+    matthewmccullough   https://help.github.com/articles/remove-sensitive-data
     Tom W.  great! thanks for that link
     Lia L.  has left the room
     Jeff    What was the slides link?
-    brntbeer    http://teach.github.com/presentations/git-found...
+    brntbeer    http://teach.github.com/presentations/git-foundations.html
 
 ## Day Two Chat
 
@@ -295,11 +295,11 @@ eventdate: 2013-03-29
     brntbeer    and what is your username on github?
     nwj nwj
     https://github.com/nwj
-    matthewmccullough   https://github.com/githubteacher/hellogitworld/...
+    matthewmccullough   https://github.com/githubteacher/hellogitworld/pulls
     8:25 AM
     matthewmccullough   git config --unset --global credential.helper
     Ken D.  in git --help I can't find graphlive
-    matthewmccullough   https://github.com/matthewmccullough/scripts/bl...
+    matthewmccullough   https://github.com/matthewmccullough/scripts/
     Ken D.  ty
     brntbeer    the graphlive is somethign we just use for demonstrative purposes. it'll be running live on the side there for a while so i hope when running it it doesnt trip people up for today =)
     nwj unset the credential
@@ -322,7 +322,7 @@ eventdate: 2013-03-29
     brntbeer    nwj: awesome. now we just have to set a different remote url
     8:35 AM
     brntbeer    nwj: type `git remote set-url origin git@github.com:githubteacher/hellogitworld.git`
-    matthewmccullough   https://github.com/githubteacher/hellogitworld/...
+    matthewmccullough   https://github.com/githubteacher/hellogitworld/pulls
     brntbeer    and verify this works by doing a "git remote -v" again
     nwj kk just pushed up
     thanks
@@ -355,7 +355,7 @@ eventdate: 2013-03-29
     Old T.  ok, it seems if you did have one user per branch then fetch is of limited value?
     8:50 AM
     Old T.  I would just pull on master to get copy of current and I have the local copy of my branch already to work offline.?
-    matthewmccullough   https://github.com/githubteacher/hellogitworld/...
+    matthewmccullough   https://github.com/githubteacher/hellogitworld/pulls
     8:55 AM
     brntbeer    Old T.: possibly, but as a social standpoint, you can see where your friends are working on, so you could coordinate when things are going into master for example
     Old T.: doing a pull updates everything locally, right
@@ -392,9 +392,9 @@ eventdate: 2013-03-29
     Evan    Thanks
     9:25 AM
     brntbeer    and, furthermore, on your PR, if you had a commit with a message that said "closes #ISSUENUMBER" it could close taht issue once the merge into master happened
-    as shown in https://github.com/blog/1439-closing-issues-acr...
+    as shown in https://github.com/blog/1439-closing-issues-across-repositories
     Evan    Spiffy - thank you!
-    brntbeer    and https://github.com/blog/1386-closing-issues-via...
+    brntbeer    and https://github.com/blog/1386-closing-issues-via-commit-messages
     so, across projects, or within the same project
     merits more online material to bring preference to those workflow things =)
     Evan    A bit off topic: what's that terminal with the split panes?

--- a/classnotes/2013-04-03-html5devconf-github-foundations.md
+++ b/classnotes/2013-04-03-html5devconf-github-foundations.md
@@ -73,7 +73,7 @@ eventdate: 2013-04-03
     Jamund F.	has entered the room
     Jamund F.	What was the URL to the slides?
     9:40 AM
-    brntbeer	http://teach.github.com/presentations/git-found... is roughly where we're at now Jamund Ferguson
+    brntbeer	http://teach.github.com/presentations/git-foundations.html is roughly where we're at now Jamund Ferguson
     Jamund F.	Thanks
     brntbeer	np!
     Ravid T.	for commit messages, basically, why instead of what right?
@@ -152,7 +152,7 @@ eventdate: 2013-04-03
     brntbeer	right, if you havent saved yet. absolutely
     Gabriela Z.	has entered the room
     brntbeer	yeah, be right there james
-    the graphlive command is at https://github.com/matthewmccullough/scripts/bl...
+    the graphlive command is at https://github.com/matthewmccullough/scripts/
     James	Thx dude
     Kristin M.	Thank you so much!
     10:30 AM
@@ -266,7 +266,7 @@ eventdate: 2013-04-03
     brntbeer	Jamund Ferguson: i can track down the conference organizer during lunch for that.
     11:30 AM
     Jamund F.	it's cool. my friendly neighbor is sharing :)
-    matthewmccullough	https://help.github.com/articles/set-up-git#pas...
+    matthewmccullough	https://help.github.com/articles/set-up-git#password-caching
     Ravid T.	dumb question, git vs github? Git = local version control system, GitHub = public Online version control system?
     brntbeer	Ravid Te: not a dumb question! Git itself is the tool that you're interacting with on your laptop, as well as the underlying technology that drive github.com. github.com is simply a better interface to interacting with more git repositories
     Ravid T.	cool, thanks for the clarifcation
@@ -286,7 +286,7 @@ eventdate: 2013-04-03
     The requested URL returned error: 403 while accessing https://github.com/derickj2004/project1.git/info/refs
 
     fatal: HTTP request failed
-    brntbeer	John Grandy: Paul betts has some good instructions here: https://github.com/blog/1104-credential-caching...
+    brntbeer	John Grandy: Paul betts has some good instructions here: https://github.com/blog/1104-credential-caching-for-wrist-friendly-git-usage
     we can go over that during lunch if you'd like as well
     Derick Johnson: can you type "git remote -v" for me?
     Derick J.	View paste 
@@ -301,7 +301,7 @@ eventdate: 2013-04-03
     never asks for username
     brntbeer	mind if i come over? you're right in front of me right?
     John G.	i was emailing Paul about this last night , but it actually caches within github for windows -- isn't there a way to cache credentials to universally available to all git clients including the command line , e.g. in the windows credential store ?
-    brntbeer	Derick Johnson: also, take a look at https://help.github.com/articles/generating-ssh..., this is essentially what we'll be following
+    brntbeer	Derick Johnson: also, take a look at https://help.github.com/articles/generating-ssh-keys, this is essentially what we'll be following
     Derick J.	ok cool
     Thanks!
     brntbeer	ah, interesting John Grandy one second while i look into that
@@ -414,7 +414,7 @@ eventdate: 2013-04-03
     matthewmccullough	https://github.com/githubteacher/hellogitworld/...
     12:50 PM
     12:55 PM
-    matthewmccullough	https://github.com/githubtraining/feedback/issu...
+    matthewmccullough	https://github.com/githubtraining/feedback/issues
     1:00 PM
     2:00 PM
     matthewmccullough	https://github.com/githubteacher/hellogitworld/...

--- a/classnotes/2013-04-15-online-foundations-class.md
+++ b/classnotes/2013-04-15-online-foundations-class.md
@@ -61,7 +61,7 @@ eventdate: 2013-04-15
     Jason L.    can we also get a copy of the slides?
     aroben  <---- This is Adam Roben. Hi everyone!
     Jennifer V. This is Jenny Vu. Hi everyone
-    matthewmccullough   http://teach.github.com/presentations/git-found...
+    matthewmccullough   http://teach.github.com/presentations/git-foundations.html
     Jason L.    anyone else from lego? :)
     Ander   Hi Matthew, I was unable to run the yum command when I tried to pull down the dependencies. are we covering this?
     aroben  what command, Ander? maybe I can help you.
@@ -119,7 +119,7 @@ eventdate: 2013-04-15
     $ git config --list
     user.name=Rich Razon
     user.email=rrazony@yahoo.com
-    aroben  Wout: you can find the slides here if you want to look at what you missed: http://teach.github.com/presentations/git-found...
+    aroben  Wout: you can find the slides here if you want to look at what you missed: http://teach.github.com/presentations/git-foundations.html
     Rich R. Should I see more than that?
     aroben  Rich: That looks great!
     aroben  Rich: nope, you should only see settings that you've set. Matthew has a lot of settings from previous classes and work. It's expected you'll only see those two.
@@ -474,7 +474,7 @@ eventdate: 2013-04-15
     Kevin K.    forked via webui. ok thanks, had someone stop in cube. thanks.
     matthewmccullough   @githubstudent
     Angie B.    how to get this page?
-    matthewmccullough   https://github.com/githubstudent/hellogitworld/...
+    matthewmccullough   https://github.com/githubstudent/hellogitworld/pulls
     Jason L.    Whats the best practice here for cloning? Should it be cloned for every task for instance? IE Im adding a new feature should I clone, then fixing a bug from the origin/master should I clone again?
     aroben  Jason: generally you'll only clone each repository once
     you'll create a fork of the repository on github.com
@@ -576,7 +576,7 @@ eventdate: 2013-04-15
 # Chat Room History Day Two
 
 
-    matthewmccullough   http://teach.github.com/classnotes/2013-04-15-o...
+    matthewmccullough   http://teach.github.com/classnotes/2013-04-15-online-foundations-class.html
     matthewmccullough   View paste 
     http://teach.github.com/classnotes/2013-04-15-online-foundations-class.html
     Jason L.    Is there good apis for controlling this or files that can be edited for this? We have hundreds of developers that we will have to maintain across different 50sh different repos.
@@ -603,7 +603,7 @@ eventdate: 2013-04-15
     git push -u origin bugfix-matthewm
     Max K.  Hi, I'm completely stuck: I think I did not set up a password. how do I set up a password for Git for Windows?
     aroben  Max: what error are you seeing?
-    Raymund R.  https://github.com/githubteachingorg/testrepo1/... ?
+    Raymund R.  https://github.com/githubteachingorg/testrepo1/ ?
     aroben  if Git asks you for a password you should use the one from your GitHub account
     Raymund: yep!
     matthewmccullough   https://github.com/githubteachingorg/testrepo1
@@ -667,7 +667,7 @@ eventdate: 2013-04-15
     Jonathan K. Could you please repost the transcript/notes url?
     Steven F.   git clone --recurse-submodules
     will bring down all code
-    Kevin K.    http://teach.github.com/classnotes/2013-04-15-o...
+    Kevin K.    http://teach.github.com/classnotes/2013-04-15-online-foundations-class.html
     Jonathan K. thanks!
     Steven F.   if you want the latest code in the submodulkes you will need to do
     git submodule foreach git pull origin master
@@ -684,7 +684,7 @@ eventdate: 2013-04-15
     Raymund R.  ok
     i asked because the webui suggested #1 after i merged
     aroben  Raymund: yes, after merging a branch there's really no need to keep it around, so the web UI suggests you delete it just so you don't have a bunch of old branches sticking around forever
-    matthewmccullough   Hey all! Just a reminder once again in case any of you have to leave early that all notes are up at: http://teach.github.com/classnotes/2013-04-15-o...
+    matthewmccullough   Hey all! Just a reminder once again in case any of you have to leave early that all notes are up at: http://teach.github.com/classnotes/2013-04-15-online-foundations-class.html
     I will append to that URL today, but that's the one and only URL for class
     with CLI history, slides, and chat room notes
     Jason L.    Does it matter which branch you have selected when you fork?
@@ -851,7 +851,7 @@ eventdate: 2013-04-15
     aroben  which means other people may have fetched or cloned them down to their own machine
     and so rebasing at this point is generally a bad idea
     aroben  Raj: you can use "git revert" to revert that 5th commit
-    matthewmccullough   http://teach.github.com/classnotes/2013-04-15-o...
+    matthewmccullough   http://teach.github.com/classnotes/2013-04-15-online-foundations-class.html
     View paste 
     http://teach.github.com/classnotes/2013-04-15-online-foundations-class.html
     aroben  it's possible you'll run into the same kind of conflict you saw when we were merging, but it shouldn't cause any other issues

--- a/classnotes/2013-04-25-online-foundations-class.md
+++ b/classnotes/2013-04-25-online-foundations-class.md
@@ -168,7 +168,7 @@ eventdate: 2013-04-25
 ## Chat History - Day One
 
     Jason S.    Good morning everyone. I'm Jason, you heard me a few minutes ago once I finally figured out the GoToTraining Client :). I will be handling any of the questions here in the room and popping in via audio from time to time.
-    matthewmccullough   http://teach.github.com/presentations/git-found...
+    matthewmccullough   http://teach.github.com/presentations/git-foundations.html
     Jason S.    Feel free to ask any questions as we go along and I'll do my best to answer.
     Alex K. git version 1.7.12.1
     John Z. 1.7.9.5
@@ -266,7 +266,7 @@ eventdate: 2013-04-25
     I am good now :)
     Joe W.  same, thanks
     Jason S.    Perfect
-    matthewmccullough   https://github.com/githubteacher/hellogitworld/...
+    matthewmccullough   https://github.com/githubteacher/hellogitworld/pulls
     Jason S.    A GitHub-specific tip: After a pull request is merged, it *cannot* be reopened with additional commits. A new pull request would be necessary to add additional changes.
     Another GitHub-specific tip: GitHub displays GitHub user names where possible, and it does so via the e-mail address. When you signed up for GitHub, you provided an e-mail address. If you specified the same address when running "git config user.email your@email.address", GitHub will display your GitHub username, linked, instead of your real name.
     Ted But you can add additional commit to pull requests for consideration (tuning), right?
@@ -296,7 +296,7 @@ eventdate: 2013-04-25
     You will probably need to use Ctrl-c to abort it and retry.
     Heath C.    at work keep getting taken away sorry
     Nick B. any good options for a gui in linux?
-    Jason S.    http://stackoverflow.com/questions/1516720/git-... has a number of answers for a number of environments.
+    Jason S.    http://stackoverflow.com/questions/1516720/git-gui-client-for-linux has a number of answers for a number of environments.
     matthewmccullough   teach.github.com/presentations/git-foundations.html
 
 ## Command Line History - Day Two
@@ -502,17 +502,17 @@ eventdate: 2013-04-25
 
 ## Chat History - Day Two
 
-    Class notes are started at: http://teach.github.com/classnotes/2013-04-25-o...
+    Class notes are started at: http://teach.github.com/classnotes/2013-04-25-online-foundations-class.html
     Updates being pushed at break and at the end of class.
     Doing some formatting to the console output
     matthewmccullough   That URL is the critical one to copy and save after class.
-    matthewmccullough   Just was saying that class notes are started at http://teach.github.com/classnotes/2013-04-25-o...
+    matthewmccullough   Just was saying that class notes are started at http://teach.github.com/classnotes/2013-04-25-online-foundations-class.html
     Ted Hi Matthew & Jason, I have specific questions which are probably better asked today... If you don't have time for them, can I send you email after class or is there another way to request help?
     John Z. Thanks
     matthewmccullough   Ted: Fire away in class and we'll do as much as possible there.
     matthewmccullough   And then, for after class, that Q&A URL on screen
     matthewmccullough   or the office hours sessions are perfect for big ones
-    matthewmccullough   http://teach.github.com/classnotes/2013-04-25-o...
+    matthewmccullough   http://teach.github.com/classnotes/2013-04-25-online-foundations-class.html
     Ted Matthew, your bottom-left autohistory window isn't updating btw.
     jasonsalaz  He'll get it going when this point wraps up :).
     jasonsalaz  Reminder: This is the project1 repository that we started with yesterday. Not the hellogitworld that we forked.
@@ -609,7 +609,7 @@ eventdate: 2013-04-25
     A    trunk/src/test/java/com/ambientideas
     A    trunk/src/test/java/com/ambientideas/AppTest.java
     Checked out revision 69.
-    matthewmccullough   http://teach.github.com/classnotes/2013-04-25-o...
+    matthewmccullough   http://teach.github.com/classnotes/2013-04-25-online-foundations-class.html
     Alex K. Thanks!
     Ted YOu guys were great. Thanks a ton!
     John Z. Thanks
@@ -635,9 +635,8 @@ eventdate: 2013-04-25
     matthewmccullough   http://teach.github.com is the top level
     John Z. We're a small team and just give everyone write access, but it would be nice to use GitHub and pull requests to do code reviews
     matthewmccullough   (all CC-By licensed)
-    http://teach.github.com/articles/git-advanced-c...
-    http://teach.github.com/articles/git-advanced-c...
-    http://teach.github.com/presentations/git-advan...
+    http://teach.github.com/articles/git-advanced-course-v2/
+    http://teach.github.com/presentations/git-advanced.html
     jasonsalaz  John, the answer differs heavily from company to company, team to team. I have seen a number of occasions where there is one master, gatekeeper-controlled repository, and all developers either have their own forks, or a fork made to another organization (when using GitHub specifically).
     We, at GitHub, all use the same repository, and do all the work on branches we create.
     Pushing the branch instantly allows other individuals to pull (or fetch) as needed and help out.


### PR DESCRIPTION
URLs get trimmed when dumped into the chatroom, and it's this version which happens to carry across when exporting the text dump.

This attempts to fix some of them, where their full address can be reasonably guessed. For the most part.

But there are some that look like they depend on context, suggested as deep links.
