### PR TITLE
Add GitHub logo to preroll slide

### DIFF
--- a/presentations/_posts/foundations/preroll/0001-01-01-Preroll.md
+++ b/presentations/_posts/foundations/preroll/0001-01-01-Preroll.md
@@ -6,6 +6,10 @@ layout: slide
 tags: ['preroll']
 ---
 
+<div class="brand"></div>
+
+---
+
 ## Classroom Chat
 <div class="pseudoLink" contenteditable>githubtraining.campfirenow.com/---</div>
 


### PR DESCRIPTION
Eliminating the ambiguity of the opening slide that previously only contains chat room placeholder and Training Team links.

Styling and theming need more attention, but this gets the first step of including GitHub branding in the markdown.

![screen shot 2013-05-21 at 11 10 14 am](https://f.cloud.github.com/assets/352082/543379/c3ef8082-c239-11e2-83e1-65636d1d7bb8.png)
