### PR TITLE
Fix windows.github.com slide links

### DIFF
--- a/presentations/_posts/education/setup/0002-01-01-GitHub-Installers.md
+++ b/presentations/_posts/education/setup/0002-01-01-GitHub-Installers.md
@@ -10,5 +10,5 @@ categories: ['slidecontent']
 	<span><i class="icon-cloud-download"> </i></span>
 	Git is easy to install on Windows too.
 
-	<a href="http://mac.github.com">windows.github.com</a>
+	<a href="http://windows.github.com">windows.github.com</a>
 </div>

--- a/presentations/_posts/foundations/setup/0002-01-01-GitHub-Installers.md
+++ b/presentations/_posts/foundations/setup/0002-01-01-GitHub-Installers.md
@@ -11,5 +11,5 @@ categories: ['slidecontent']
 	Git is easy to install.
 
 	<a href="http://mac.github.com">mac.github.com</a>
-	<a href="http://mac.github.com">windows.github.com</a>
+	<a href="http://windows.github.com">windows.github.com</a>
 </div>


### PR DESCRIPTION
Addressing issue https://github.com/github/teach.github.com/issues/151, commit corrects links in two slides for Foundations content for windows.github.com references.
