### PR TITLE
Fix malformed Markdown links in bumpers, Foundations slides

### DIFF
--- a/presentations/_posts/bumpers/goodbye/0001-01-01-goodbye.md
+++ b/presentations/_posts/bumpers/goodbye/0001-01-01-goodbye.md
@@ -21,4 +21,4 @@ categories: ['slidecontent']
 ---
 
 ### Training Team Q&A
-[github.com/githubtraining/feedback](githubtraining/feedback/)
+[github.com/githubtraining/feedback](https://github.com/githubtraining/feedback/)

--- a/presentations/_posts/foundations/gui/0002-01-01-Other-Tools.md
+++ b/presentations/_posts/foundations/gui/0002-01-01-Other-Tools.md
@@ -7,8 +7,8 @@ categories: ['slidecontent']
 
 __GitHub for Windows__
 
-[https://windows.github.com](windows.github.com)
+[windows.github.com](https://windows.github.com)
 
 __GitHub for Mac__
 
-[https://mac.github.com](mac.github.com)
+[mac.github.com](https://mac.github.com)


### PR DESCRIPTION
Piggyback on #152 and related to #151 where the Markdown link formats are backwards.
