### PR TITLE
Fix RevealJS slide deck template to support rev-ed HydeSlide Plugins

### DIFF
--- a/_includes/hydeslides/revealjs/slidedeck
+++ b/_includes/hydeslides/revealjs/slidedeck
@@ -1,4 +1,4 @@
-<div class="reveal">
+<div class="reveal" id="reveal">
 	<div class="slides">
 		{% for ch in page.chapters %}
 			<!--Nest all chapter's content. Chapters traverse left-right; Sections slide up-down-->


### PR DESCRIPTION
Added missing `id` value for DOM selector in HydeSlide Plugins which now queries for which slide deck template is in use.
