### PR TITLE
use awk instead

### DIFF
--- a/presentations/_posts/foundations/reflog/0001-01-01-Restoring-by-Action.md
+++ b/presentations/_posts/foundations/reflog/0001-01-01-Restoring-by-Action.md
@@ -15,7 +15,7 @@ categories: ['slidecontent']
 	* rebase
 	* reset
 
-* `gitk --all `git reflog | cut -c1-7``
+* `gitk --all `git reflog | awk '{print $1}'``
 * `git log --pretty=oneline --abbrev-commit --graph --decorate `git reflog | cut -c1-7``
 
 * `git reflog expire --expire=now --all`

--- a/presentations/_posts/foundations/reflog/0001-01-01-Restoring-by-Action.md
+++ b/presentations/_posts/foundations/reflog/0001-01-01-Restoring-by-Action.md
@@ -16,7 +16,7 @@ categories: ['slidecontent']
 	* reset
 
 * `gitk --all `git reflog | awk '{print $1}'``
-* `git log --pretty=oneline --abbrev-commit --graph --decorate `git reflog | cut -c1-7``
+* `git log --pretty=oneline --abbrev-commit --graph --decorate `git reflog | awk '{print $1}'``
 
 * `git reflog expire --expire=now --all`
 {% endcapture %}


### PR DESCRIPTION
Using awk instead of cut to avoid ambiguous reference. 

![screen shot 2013-05-28 at 1 20 57 pm](https://f.cloud.github.com/assets/45141/574219/d90dcf52-c7c3-11e2-8f98-5808ed05d3f7.png)

used `cut -c1-4` to force ambiguous error on git/git project, but it can still pop up in smaller projects for the first 7 characters.

/cc @matthewmccullough to also update your dotfiles.
