### PR TITLE
use explicit jekyll command over rake file

### DIFF
--- a/script/server
+++ b/script/server
@@ -2,4 +2,4 @@
 
 set -e
 
-bundle exec rake server
+bundle exec jekyll --server --auto


### PR DESCRIPTION
For some odd reason, the rake task we previously had would cause me to get 403 Forbidden from Webrick. Not sure if that was a permissions thing on the `Rakefile` or the rake script not having `bundle exec jekyll --server --auto` or what, seemed to be hit or miss. After a few times of getting a 403, i'd refresh hard enough and it'd finally go through to the page.

I personally don't use any rake commands often at all. I'm almost more in favor of only having one abstracted command to start something instead of having a `rake server` and `script/server` that do the same thing.
