### PR TITLE
Update HydeSlide-Plugins rev, include new Help module JS

### DIFF
--- a/_includes/hydeslides/revealjs/scripts
+++ b/_includes/hydeslides/revealjs/scripts
@@ -26,3 +26,4 @@
 </script>
 
 <script src="dependencies/plugins/launcher/launcher.js"></script>
+<script src="dependencies/plugins/help/help.js"></script>


### PR DESCRIPTION
With updated HydeSlides-Plugins rev, now including the Help
JavaScript module for RevealJS decks.
