### PR TITLE
Fix cherry-pick language in presenter notes

### DIFF
--- a/presentations/_posts/advanced/cherry-pick/0003-01-01-Verifying-by-Patch.md
+++ b/presentations/_posts/advanced/cherry-pick/0003-01-01-Verifying-by-Patch.md
@@ -10,7 +10,7 @@ tags: ['advanced/cherry-pick']
 
 {% capture notes %}
 * Cherry uses `patch-id`, SHA1 of patch diff
-	* `-` Merged to Upstream
+	* `-` Applied to Upstream
 	* `+` Only in HEAD
 {% endcapture %}
 {% include hydeslides/core/notes %}


### PR DESCRIPTION
This addresses the issue brought up [here](https://github.com/github/teach.github.com/issues/28) and the notes on the Cherry Pick.
