### PR TITLE
Update prerequisites to reference GitHub platform-specific installers

### DIFF
--- a/courses/_posts/2001-02-28-github-class-prerequisites.md
+++ b/courses/_posts/2001-02-28-github-class-prerequisites.md
@@ -29,21 +29,22 @@ We request that you use [version 1.7.9](https://github.com/git/git/blob/master/D
 1. It is absolutely best if Git is version _1.7.11_ or higher to match the behavior of your instructor's machine. However, no actual repository incompatibilities will be encountered during class if your installed version is _1.7.9_ or newer.
 2. Git's version can be queried by running `git --version` at the terminal or command prompt.
 
-### and for _Windows_ Machines
-1. The preferred installation is from the Download button at:  
-  <http://windows.github.com>
-2. Another option for advanced users is to use MSysGit:
-  <http://git-scm.com/download/win>
+### For _Windows_ Machines
+Download the installer from <https://windows.github.com>. This provides the Git Shell running latest version of Git and a Windows graphical user interface.
 
-### and for _Mac OS X_ Machines
-1. Install the command line edition of Git from the package available at:  
-  <http://git-scm.com/download/mac>
-2. The location of the installed Git can be found with the command `which git`.
+### For _Mac OS X_ Machines
+Download the installer from <https://mac.github.com>. This provides a Mac OS X  graphical user interface and optional setup of Git and GitHub command line utilties.
+
+__Checking Git Installation__
+
+Your Mac may already have Git installed. To verify, follow these steps:
+
+1. The location of the installed Git can be found with the command `which git`.
 3. If `usr/bin/git`, it was likely installed by Apple or [Xcode](https://developer.apple.com/xcode/).
 4. If `usr/local/bin/git` it was likely installed by [Homebrew](http://mxcl.github.com/homebrew/).
 5. `PATH` order may need to be modified to get the newly installed Git in "front" of other Git installations.
 
-### and for _Linux_ Machines
+### _Linux_ Machines
 1. Git will likely already be installed. It is present in most modern Linux distributions.
 2. Package managers such as _Synaptic_, `yum` and `apt-get` are the best way to install and update Git.
 3. The Git source code can be obtained and compiled from the [Git mirror on GitHub](https://github.com/git/git).


### PR DESCRIPTION
With Training Team Foundation classes focusing on a more thorough tour of the GHfW and GHfM apps, the prerequisites document now includes revised setup/installation instructions to exclusively point to https://windows.github.com and http://mac.github.com.

@github/training-team Can you take a look at this?
