### PR TITLE
Fix GitHub casing in slides and a little consistent use of YAML example, links

### DIFF
--- a/presentations/_posts/advanced/bisect/0003-01-01-Identifying-Bad-Commits.md
+++ b/presentations/_posts/advanced/bisect/0003-01-01-Identifying-Bad-Commits.md
@@ -7,7 +7,7 @@ tags: ['advanced/bisect']
 	# Begin process
 	git bisect start
 
-	# Denote known bad Commit
+	# Denote known bad commit
 	git bisect bad <rev>
 
 	# Flag good commit

--- a/presentations/_posts/advanced/github-way/0001-01-01-Deployable-Branch.md
+++ b/presentations/_posts/advanced/github-way/0001-01-01-Deployable-Branch.md
@@ -5,7 +5,7 @@ tags: ['advanced/github-way']
 ---
 
 `master` branch is deployable
-and never directly commited upon
+and never directly committed upon
 
 {% capture notes %}
 * Involving team

--- a/presentations/_posts/foundations/github/intro/0001-01-01-GitHub-Hosted-Repo.md
+++ b/presentations/_posts/foundations/github/intro/0001-01-01-GitHub-Hosted-Repo.md
@@ -1,6 +1,7 @@
 ---
 chapter: GitHub
 layout: slide
+title: GitHub Hosted Repo
 tags: ['github/intro']
 ---
 

--- a/presentations/_posts/foundations/github/intro/0002-01-01-Cloning-from-GitHub.md
+++ b/presentations/_posts/foundations/github/intro/0002-01-01-Cloning-from-GitHub.md
@@ -1,6 +1,7 @@
 ---
 chapter: GitHub
 layout: slide
+title: Cloning From GitHub
 tags: ['github/intro']
 ---
 

--- a/presentations/_posts/foundations/ignore/0004-01-01-Excludes-File.md
+++ b/presentations/_posts/foundations/ignore/0004-01-01-Excludes-File.md
@@ -5,7 +5,7 @@ tags: ['ignore']
 categories: ['slidecontent']
 ---
 
-Avoid commiting undesired environment files
+Avoid committing undesired environment files
 
 * Create a machine-specific ignore
 * Save the file outside of the repo

--- a/presentations/_posts/foundations/setup/0001-01-01-GitHub-Account.md
+++ b/presentations/_posts/foundations/setup/0001-01-01-GitHub-Account.md
@@ -10,5 +10,5 @@ categories: ['slidecontent']
 	<span><i class="icon-github"> </i></span>
 
 	GitHub Account
-	<a href="http://github.com/signup/free">http://github.com/signup/free</a>
+	<a href="https://github.com/signup/free">github.com/signup/free</a>
 </div>

--- a/presentations/_posts/foundations/why-git-vcs/0001-01-02-What-is-the-benefit-of-GitHub.md
+++ b/presentations/_posts/foundations/why-git-vcs/0001-01-02-What-is-the-benefit-of-GitHub.md
@@ -1,6 +1,7 @@
 ---
 chapter: Why Git?
 layout: slide
+title: What is the benefit of GitHub?
 tags: ['why-git-vcs']
 ---
 

--- a/presentations/_posts/pages/jekyll/0003-01-01-github-pages-serving.md
+++ b/presentations/_posts/pages/jekyll/0003-01-01-github-pages-serving.md
@@ -2,6 +2,7 @@
 chapter: "Jekyll"
 cover: true
 layout: hydeside
+title: GitHub Pages Serving
 tags:
   - "pages/jekyll"
 categories: ['slidecontent']

--- a/presentations/_posts/pages/jekyll/0005-01-01-yaml.md
+++ b/presentations/_posts/pages/jekyll/0005-01-01-yaml.md
@@ -2,6 +2,7 @@
 chapter: "Jekyll"
 cover: true
 layout: hydeside
+title: YAML
 tags:
   - "pages/jekyll"
 categories: ['slidecontent']

--- a/presentations/_posts/pages/jekyll/0006-01-01-front-matter-example.md
+++ b/presentations/_posts/pages/jekyll/0006-01-01-front-matter-example.md
@@ -9,7 +9,7 @@ categories: ['slidecontent']
 
 At its most basic level, YAML is simply a set of properties and values separated by a colon (`:`). For example:
 
-       ----
+       ---
        title: Hello world!
        layout: page
-       ----
+       ---

--- a/presentations/_posts/pages/jekyll/0007-01-01-yaml-behavior.md
+++ b/presentations/_posts/pages/jekyll/0007-01-01-yaml-behavior.md
@@ -2,6 +2,7 @@
 chapter: "Jekyll"
 cover: true
 layout: hydeside
+title: YAML Behavior
 tags:
   - "pages/jekyll"
 categories: ['slidecontent']

--- a/presentations/_posts/pages/layouts/0002-01-01-layout-example.md
+++ b/presentations/_posts/pages/layouts/0002-01-01-layout-example.md
@@ -16,7 +16,7 @@ categories: ['slidecontent']
         </body>
         </html>
 
-* so now `index.html` should now just contain:
+* so now `index.html` should just contain:
 
         <h1>Hello World!</h1>
 

--- a/presentations/_posts/pages/template-data/0004-01-01-lets-take-a-look-part-deux.md
+++ b/presentations/_posts/pages/template-data/0004-01-01-lets-take-a-look-part-deux.md
@@ -2,6 +2,7 @@
 chapter: "Template Data"
 cover: true
 layout: hydesides
+title: Let's Take A Look Part Deux
 tags:
   - "pages/template-data"
 categories: ['slidecontent']


### PR DESCRIPTION
A few slipped through after you [fixed the filename issue for those looking on Windows](https://github.com/github/teach.github.com/issues/139).
- Pump up the H in GitHub
- And the YAML all caps as is polite.

The YAML slide says you can use three or more hyphens, and it was odd the first use was four, and nowhere else. 

Signup link appears to be the only one loaded with http for its display. Other links just jump right into the subdomain part.
