### PR TITLE
Missing preposition in account signup notes; Unhide refspec mention

### DIFF
--- a/courses/_posts/2001-02-26-git-intermediate-course.md
+++ b/courses/_posts/2001-02-26-git-intermediate-course.md
@@ -113,11 +113,11 @@ Topics covered include:
 ## Pushing to and pulling from multiple destinations.
 Refspecs only allow for a wildcard as the last element, after a slash. It cannot be part of the name itself. For example, a disallowed pattern would be `+refs/heads/t*:refs/remotes/origin/t*` to pull all of TM's and TJ's branches. An allowed pattern would be `+refs/heads/tm/*:refs/remotes/origin/tm/*` to pull only TM's branches.
 
-Refspecs can be given on `push` to change the destination of a push on the remote side. Keep in mind that the pattern is still <source>:<dest>, but we're transmitting in the opposite direction than a pull or fetch.
+Refspecs can be given on `push` to change the destination of a push on the remote side. Keep in mind that the pattern is still `<source>:<dest>`, but we're transmitting in the opposite direction than a pull or fetch.
 
     git push origin master:refs/heads/tm/master
 
-Some types of objects don't sit under the `refs/heads` folder and thus don't get pulled by the default refspec created for a cloned repository. It is easy to fetch things that normally wouldn't get fetched ([but are displayed on GitHub](https://github.com/blog/707-git-notes-display))by specifying a refspec on the command line, but this can get tedious, time after time.
+Some types of objects don't sit under the `refs/heads` folder and thus don't get pulled by the default refspec created for a cloned repository. It is easy to fetch things that normally wouldn't get fetched ([but are displayed on GitHub](https://github.com/blog/707-git-notes-display)) by specifying a refspec on the command line, but this can get tedious, time after time.
 
     git push origin refs/notes/commits
 

--- a/courses/_posts/2001-02-28-github-class-prerequisites.md
+++ b/courses/_posts/2001-02-28-github-class-prerequisites.md
@@ -12,7 +12,7 @@ This document outlines the requirements for preparing your account and laptop pr
 1) Establish a GitHub.com Account
 ----------------------------------------------------------
 We'd like you to establish a GitHub account to facilitate hands-on practice of the network flow components of Git during class.  A free account can be established at the
-[GitHub Signup Page](http://github.com/signup/free). We'd also recommend you [take a look at our supported browsers](https://help.github.com/articles/supported-browsers) after you signup ensure the best experience.
+[GitHub Signup Page](https://github.com/signup/free). We also recommend that you [take a look at our supported browsers](https://help.github.com/articles/supported-browsers) after you signup to ensure the best experience.
 
 **Please keep your username and password close at hand. You'll use it several times during class.**
 
@@ -33,7 +33,7 @@ We request that you use [version 1.7.9](https://github.com/git/git/blob/master/D
 Download the installer from <https://windows.github.com>. This provides the Git Shell running latest version of Git and a Windows graphical user interface.
 
 ### For _Mac OS X_ Machines
-Download the installer from <https://mac.github.com>. This provides a Mac OS X  graphical user interface and optional setup of Git and GitHub command line utilties.
+Download the installer from <https://mac.github.com>. This provides a Mac OS X  graphical user interface and optional setup of Git and GitHub command line utilities.
 
 __Checking Git Installation__
 


### PR DESCRIPTION
Flattened out the contraction in "Establish a GitHub.com Account" to help improve the overall sentence flow.

Refspec mention on "Git Beyond the Basics" missing the backticks which hid the chunk from showing up rendered at: http://teach.github.com/articles/git-intermediate-course/
