### PR TITLE
Add Git & GitHub prerequisites page

### DIFF
--- a/resources/_posts/2001-01-01-prerequisites.md
+++ b/resources/_posts/2001-01-01-prerequisites.md
@@ -1,0 +1,11 @@
+---
+layout: barewithrelated
+title: Prerequisites
+description: Setup and requiments for Git and GitHub usage
+path: resources/_posts/2001-01-01-prerequisites.md
+---
+
+
+* [Git & GitHub Prerequisites](http://teach.github.com/articles/github-class-prerequisites/)
+
+* [GitHub Supported Browsers](https://help.github.com/articles/supported-browsers)


### PR DESCRIPTION
I can't remember if we found that this already existed or what, but thought I'd open this up for either completion or closure.  Did we have a reason to have this as a unique page from http://teach.github.com/articles/github-class-prerequisites/ @jordanmccullough ?
