### PR TITLE
H4 headings need to step inside a bit from the margin

### DIFF
--- a/stylesheets/page.css
+++ b/stylesheets/page.css
@@ -252,9 +252,9 @@ h2 {
   /* text-transform: lowercase; */
   color: #fff; }
 
-h3 {
+h3, h4 {
   color: #636363;
-  padding: 12px 25px 0px; }
+  padding: 12px 25px 0; }
 
 a:link, a:visited, a:hover, a:active {
   text-decoration: none; }


### PR DESCRIPTION
This mostly affects classnotes that have H4 elements, such as [Private Advanced Git Training classnotes](http://teach.github.com/classnotes/2013-09-10-advanced-git-at-javazone.html)
