### PR TITLE
Update header style padding to fix alignment

### DIFF
--- a/stylesheets/page.css
+++ b/stylesheets/page.css
@@ -252,9 +252,9 @@ h2 {
   /* text-transform: lowercase; */
   color: #fff; }
 
-h3 {
+h3, h4 {
   color: #636363;
-  padding: 12px 25px 0px; }
+  padding: 12px 25px 0; }
 
 a:link, a:visited, a:hover, a:active {
   text-decoration: none; }

--- a/stylesheets/page.scss
+++ b/stylesheets/page.scss
@@ -332,9 +332,9 @@ h2 {
   color: #fff;
 }
 
-h3 {
+h3, h4 {
   color: #636363;
-  padding: 12px 25px 0px;
+  padding: 12px 25px 0;
 }
 
 a:link,a:visited,a:hover,a:active {


### PR DESCRIPTION
Include h4 padding definition same as h3 to avoid on-the-edge heading titles.

This addresses @randomecho's [PR 202](https://github.com/github/teach.github.com/pull/202) and includes the change to the source SCSS file.
