### PR TITLE
Revised Commit Shorthand Examples

### DIFF
--- a/presentations/_posts/foundations/commit/0005-01-01-Current-Branch-Tip.md
+++ b/presentations/_posts/foundations/commit/0005-01-01-Current-Branch-Tip.md
@@ -4,13 +4,9 @@ layout: slide
 tags: ['commit']
 ---
 
-Three Prior to Last Commit using `HEAD`
+Last Commit of Current Branch
 
-    HEAD~3
-
-or with a hash-based reference
-
-    3ec81~3
+    HEAD
 
 {% capture notes %}
 

--- a/presentations/_posts/foundations/commit/0006-01-01-Parent-Reference.md
+++ b/presentations/_posts/foundations/commit/0006-01-01-Parent-Reference.md
@@ -4,13 +4,11 @@ layout: slide
 tags: ['commit']
 ---
 
-Parent / One Prior to Last Commit
+    # Parent / One Prior to Last Commit
+    HEAD^
 
-94fc2__^__
-
-
-
-
+    # Parent of Specific Commit Ref
+    94fc2^
 
 {% capture notes %}
 

--- a/presentations/_posts/foundations/commit/0007-01-01-Ancestor-Reference.md
+++ b/presentations/_posts/foundations/commit/0007-01-01-Ancestor-Reference.md
@@ -4,13 +4,11 @@ layout: slide
 tags: ['commit']
 ---
 
-Last Commit of Current Branch
+    # Three Prior to Last Commit
+    HEAD~3
 
-__HEAD__
-
-
-
-
+    # Three Prior of Specific Commit Ref
+    3ec81~3
 
 {% capture notes %}
 


### PR DESCRIPTION
Commit shorthand slides contained Markdown syntax errors and inconsistent content style from other slides. This addresses those problems and inconsistencies.

![screen shot 2013-09-30 at 4 46 09 pm](https://f.cloud.github.com/assets/352082/1241608/1f94ee54-2a22-11e3-8f8d-b7bbb845ddcc.png)
