### PR TITLE
Fixes the link back to the source of the page

### DIFF
--- a/courses/_posts/2001-02-23-github-chatops-presentation.md
+++ b/courses/_posts/2001-02-23-github-chatops-presentation.md
@@ -2,7 +2,7 @@
 layout: barewithrelated
 title: GitHub Chatops Course Script
 description: Transcript of a silent presentation about GitHub ChatOps
-path: courses/_posts/2001-01-01-github-chatops-presentation.md
+path: courses/_posts/2001-02-23-github-chatops-presentation.md
 tags: [outline, course]
 ---
 


### PR DESCRIPTION
The `View it on Github` link was pointing to the wrong place and giving a 404 error, I think this should fix the link.
