### PR TITLE
Remove "categories" unused YAML

### DIFF
--- a/presentations/_posts/0001-01-01-title-Template.md
+++ b/presentations/_posts/0001-01-01-title-Template.md
@@ -3,5 +3,4 @@ chapter: Title
 layout: slide
 title: ''
 tags: ['chapter-name']
-categories: ['slidecontent']
 ---

--- a/presentations/_posts/api/0001-01-01-How-do-I-test-it.md
+++ b/presentations/_posts/api/0001-01-01-How-do-I-test-it.md
@@ -3,7 +3,6 @@ chapter: API
 layout: slide
 title: How do I test it?
 tags: ['api']
-categories: ['slidecontent']
 ---
 
     # Anonymous

--- a/presentations/_posts/api/0001-01-02-What-URL-do-I-use.md
+++ b/presentations/_posts/api/0001-01-02-What-URL-do-I-use.md
@@ -3,7 +3,6 @@ chapter: API
 layout: slide
 title: What URL do I use?
 tags: ['api']
-categories: ['slidecontent']
 ---
 
 	$ curl -n https://api.github.com

--- a/presentations/_posts/api/0001-01-03-What-can-it-do.md
+++ b/presentations/_posts/api/0001-01-03-What-can-it-do.md
@@ -3,7 +3,6 @@ chapter: API
 layout: slide
 title: What can it do?
 tags: ['api']
-categories: ['slidecontent']
 ---
 
 	$ curl -n https://api.github.com

--- a/presentations/_posts/api/0001-01-04-What-can-it-do.md
+++ b/presentations/_posts/api/0001-01-04-What-can-it-do.md
@@ -3,7 +3,6 @@ chapter: API
 layout: slide
 title: What can it do?
 tags: ['api']
-categories: ['slidecontent']
 ---
 
 	$ curl -n https://api.github.com

--- a/presentations/_posts/api/0001-01-05-What-can-it-do.md
+++ b/presentations/_posts/api/0001-01-05-What-can-it-do.md
@@ -3,7 +3,6 @@ chapter: API
 layout: slide
 title: What can it do?
 tags: ['api']
-categories: ['slidecontent']
 ---
 
 	$ curl -n https://api.github.com

--- a/presentations/_posts/api/0001-01-06-Documentation.md
+++ b/presentations/_posts/api/0001-01-06-Documentation.md
@@ -2,7 +2,6 @@
 chapter: API
 layout: slide
 tags: ['api']
-categories: ['slidecontent']
 ---
 
 <http://developer.github.com>

--- a/presentations/_posts/api/0001-01-07-Browser-testing-an-API-call.md
+++ b/presentations/_posts/api/0001-01-07-Browser-testing-an-API-call.md
@@ -2,7 +2,6 @@
 chapter: API
 layout: slide
 tags: ['api']
-categories: ['slidecontent']
 ---
 
 You can even just HTTP GET an API URL in a web browser.

--- a/presentations/_posts/api/0001-01-08-curl-a-user's-profile.md
+++ b/presentations/_posts/api/0001-01-08-curl-a-user's-profile.md
@@ -2,7 +2,6 @@
 chapter: API
 layout: slide
 tags: ['api']
-categories: ['slidecontent']
 ---
 
 You can _GET_ data about a user with a simple `curl` call.

--- a/presentations/_posts/bumpers/goodbye/0001-01-01-goodbye.md
+++ b/presentations/_posts/bumpers/goodbye/0001-01-01-goodbye.md
@@ -4,7 +4,6 @@ cover: false
 heading: false
 layout: slide
 tags: ['goodbye']
-categories: ['slidecontent']
 ---
 
 ### Training Courses & Free Classes

--- a/presentations/_posts/bumpers/trainers/brent-beer/0001-01-01-brent-beer.md
+++ b/presentations/_posts/bumpers/trainers/brent-beer/0001-01-01-brent-beer.md
@@ -3,7 +3,6 @@ chapter: 'Trainer'
 cover: false
 layout: slide
 tags: ['trainers/brent-beer']
-categories: ['slidecontent']
 ---
 
 <img class="headshot" src="assets/headshots/beer-brent.jpg" alt="Brent Beer">

--- a/presentations/_posts/bumpers/trainers/jordan-mccullough/0001-01-01-jordan-mccullough.md
+++ b/presentations/_posts/bumpers/trainers/jordan-mccullough/0001-01-01-jordan-mccullough.md
@@ -3,7 +3,6 @@ chapter: 'Trainer'
 cover: false
 layout: slide
 tags: ['trainers/jordan-mccullough']
-categories: ['slidecontent']
 ---
 
 <img class="headshot" src="assets/headshots/mccullough-jordan.jpg" alt="Jordan McCullough">

--- a/presentations/_posts/bumpers/trainers/matthew-mccullough/0001-01-01-matthew-mccullough.md
+++ b/presentations/_posts/bumpers/trainers/matthew-mccullough/0001-01-01-matthew-mccullough.md
@@ -3,7 +3,6 @@ chapter: 'Trainer'
 cover: false
 layout: slide
 tags: ['trainers/matthew-mccullough']
-categories: ['slidecontent']
 ---
 
 <img class="headshot" src="assets/headshots/mccullough-matthew.jpg" alt="Matthew McCullough">

--- a/presentations/_posts/bumpers/trainers/tim-berglund/0001-01-01-tim-berglund.md
+++ b/presentations/_posts/bumpers/trainers/tim-berglund/0001-01-01-tim-berglund.md
@@ -3,7 +3,6 @@ chapter: 'Trainer'
 cover: false
 layout: slide
 tags: ['trainers/tim-berglund']
-categories: ['slidecontent']
 ---
 
 <img class="headshot" src="assets/headshots/berglund-tim.jpg" alt="Tim Berglund">

--- a/presentations/_posts/education/branch/0001-01-01-Development-Flexibility.md
+++ b/presentations/_posts/education/branch/0001-01-01-Development-Flexibility.md
@@ -2,7 +2,6 @@
 chapter: Branch
 layout: slide
 tags: ['education/branch']
-categories: ['slidecontent']
 ---
 
 * Branches are _cheap_

--- a/presentations/_posts/education/branch/0001-01-01-List-Branches.md
+++ b/presentations/_posts/education/branch/0001-01-01-List-Branches.md
@@ -2,7 +2,6 @@
 chapter: Branch
 layout: slide
 tags: ['education/branch']
-categories: ['slidecontent']
 ---
 
     #List (Local) Branches

--- a/presentations/_posts/education/branch/0002-01-01-Create-a-Branch.md
+++ b/presentations/_posts/education/branch/0002-01-01-Create-a-Branch.md
@@ -2,7 +2,6 @@
 chapter: Branch
 layout: slide
 tags: ['education/branch']
-categories: ['slidecontent']
 ---
 
     # Create a branch and then switch to it

--- a/presentations/_posts/education/branch/0003-01-01-Delete-a-Branch.md
+++ b/presentations/_posts/education/branch/0003-01-01-Delete-a-Branch.md
@@ -2,7 +2,6 @@
 chapter: Branch
 layout: slide
 tags: ['education/branch']
-categories: ['slidecontent']
 ---
 
     # Delete if branch is merged with upstream

--- a/presentations/_posts/education/setup/0001-01-01-Git-Version.md
+++ b/presentations/_posts/education/setup/0001-01-01-Git-Version.md
@@ -2,7 +2,6 @@
 chapter: Setup
 layout: slide
 tags: ['education/setup']
-categories: ['slidecontent']
 ---
 
 Check your version (if it is already installed)

--- a/presentations/_posts/education/setup/0002-01-01-GitHub-Installers.md
+++ b/presentations/_posts/education/setup/0002-01-01-GitHub-Installers.md
@@ -3,7 +3,6 @@ chapter: Setup
 heading: false
 layout: slide
 tags: ['education/setup']
-categories: ['slidecontent']
 ---
 
 <div class="sticky">

--- a/presentations/_posts/foundations/alias/0001-01-01-Creating-an-Alias.md
+++ b/presentations/_posts/foundations/alias/0001-01-01-Creating-an-Alias.md
@@ -2,7 +2,6 @@
 chapter: Alias
 layout: slide
 tags: ['alias']
-categories: ['slidecontent']
 ---
 
 Command shortcuts

--- a/presentations/_posts/foundations/branch/0001-01-01-Flexibility.md
+++ b/presentations/_posts/foundations/branch/0001-01-01-Flexibility.md
@@ -2,7 +2,6 @@
 chapter: Branch
 layout: slide
 tags: ['branch']
-categories: ['slidecontent']
 ---
 
 * Branches are _cheap_

--- a/presentations/_posts/foundations/branch/0001-01-01-Listing.md
+++ b/presentations/_posts/foundations/branch/0001-01-01-Listing.md
@@ -2,7 +2,6 @@
 chapter: Branch
 layout: slide
 tags: ['branch']
-categories: ['slidecontent']
 ---
 
 	#List (Local) Branches

--- a/presentations/_posts/foundations/branch/0002-01-01-Creating.md
+++ b/presentations/_posts/foundations/branch/0002-01-01-Creating.md
@@ -2,7 +2,6 @@
 chapter: Branch
 layout: slide
 tags: ['branch']
-categories: ['slidecontent']
 ---
 
     git branch <branchname> <ref>

--- a/presentations/_posts/foundations/branch/0003-01-01-Deleting.md
+++ b/presentations/_posts/foundations/branch/0003-01-01-Deleting.md
@@ -2,7 +2,6 @@
 chapter: Branch
 layout: slide
 tags: ['branch']
-categories: ['slidecontent']
 ---
 
 	# Delete if branch is merged with upstream

--- a/presentations/_posts/foundations/branch/0005-01-01-Renaming.md
+++ b/presentations/_posts/foundations/branch/0005-01-01-Renaming.md
@@ -2,7 +2,6 @@
 chapter: Branch
 layout: slide
 tags: ['branch']
-categories: ['slidecontent']
 ---
 
 	# Change branch name

--- a/presentations/_posts/foundations/gui/0001-01-01-Native-Tools.md
+++ b/presentations/_posts/foundations/gui/0001-01-01-Native-Tools.md
@@ -2,7 +2,6 @@
 chapter: GUIs
 layout: slide
 tags: ['gui']
-categories: ['slidecontent']
 ---
 
 	# Committing

--- a/presentations/_posts/foundations/gui/0002-01-01-Other-Tools.md
+++ b/presentations/_posts/foundations/gui/0002-01-01-Other-Tools.md
@@ -2,7 +2,6 @@
 chapter: GUIs
 layout: slide
 tags: ['gui']
-categories: ['slidecontent']
 ---
 
 __GitHub for Windows__

--- a/presentations/_posts/foundations/history/0001-01-01-A-Quick-History.md
+++ b/presentations/_posts/foundations/history/0001-01-01-A-Quick-History.md
@@ -2,5 +2,4 @@
 chapter: "Git's Origin"
 layout: slide
 tags: ['history']
-categories: ['slidecontent']
 ---

--- a/presentations/_posts/foundations/history/0002-01-01-Git-Tracks-Content.md
+++ b/presentations/_posts/foundations/history/0002-01-01-Git-Tracks-Content.md
@@ -2,7 +2,6 @@
 chapter: 'Git History'
 layout: slide
 tags: ['history']
-categories: ['slidecontent']
 ---
 
 Git tracks __content__

--- a/presentations/_posts/foundations/ignore/0001-01-01-Ignoring-Files.md
+++ b/presentations/_posts/foundations/ignore/0001-01-01-Ignoring-Files.md
@@ -2,7 +2,6 @@
 chapter: Ignore
 layout: slide
 tags: ['ignore']
-categories: ['slidecontent']
 ---
 
 * Create a `.gitignore` file

--- a/presentations/_posts/foundations/ignore/0002-01-01-Ignore-Patterns.md
+++ b/presentations/_posts/foundations/ignore/0002-01-01-Ignore-Patterns.md
@@ -2,7 +2,6 @@
 chapter: Ignore
 layout: slide
 tags: ['ignore']
-categories: ['slidecontent']
 ---
 
 	# Anything ending ".log"

--- a/presentations/_posts/foundations/ignore/0003-01-01-Controlling-Ignores.md
+++ b/presentations/_posts/foundations/ignore/0003-01-01-Controlling-Ignores.md
@@ -2,7 +2,6 @@
 chapter: Ignore
 layout: slide
 tags: ['ignore']
-categories: ['slidecontent']
 ---
 
 * Nest .gitignore file for granular control

--- a/presentations/_posts/foundations/ignore/0004-01-01-Excludes-File.md
+++ b/presentations/_posts/foundations/ignore/0004-01-01-Excludes-File.md
@@ -2,7 +2,6 @@
 chapter: Ignore
 layout: slide
 tags: ['ignore']
-categories: ['slidecontent']
 ---
 
 Avoid committing undesired environment files

--- a/presentations/_posts/foundations/ignore/0005-01-01-Excludes-File.md
+++ b/presentations/_posts/foundations/ignore/0005-01-01-Excludes-File.md
@@ -2,7 +2,6 @@
 chapter: Ignore
 layout: slide
 tags: ['ignore']
-categories: ['slidecontent']
 ---
 
 	$ git config --global core.excludesfile "~/.gitignore"

--- a/presentations/_posts/foundations/init/0001-01-01-Repository-from-Scratch.md
+++ b/presentations/_posts/foundations/init/0001-01-01-Repository-from-Scratch.md
@@ -2,7 +2,6 @@
 chapter: Init
 layout: slide
 tags: ['init']
-categories: ['slidecontent']
 ---
 
 	# New project

--- a/presentations/_posts/foundations/init/0002-01-01-Repository-from-Existing-Dir.md
+++ b/presentations/_posts/foundations/init/0002-01-01-Repository-from-Existing-Dir.md
@@ -2,7 +2,6 @@
 chapter: Init
 layout: slide
 tags: ['init']
-categories: ['slidecontent']
 ---
 
 	# Legacy project tree

--- a/presentations/_posts/foundations/merge/0001-01-01-Basics.md
+++ b/presentations/_posts/foundations/merge/0001-01-01-Basics.md
@@ -2,7 +2,6 @@
 chapter: Merge
 layout: slide
 tags: ['merge']
-categories: ['slidecontent']
 ---
 
 	git checkout master

--- a/presentations/_posts/foundations/merge/0002-01-01-Recursive.md
+++ b/presentations/_posts/foundations/merge/0002-01-01-Recursive.md
@@ -2,7 +2,6 @@
 chapter: Merge
 layout: slide
 tags: ['merge','diagram']
-categories: ['slidecontent']
 ---
 
 <div class="diagram-group">

--- a/presentations/_posts/foundations/merge/0003-01-01-Fast-Forward.md
+++ b/presentations/_posts/foundations/merge/0003-01-01-Fast-Forward.md
@@ -2,7 +2,6 @@
 chapter: Merge
 layout: slide
 tags: ['merge','diagram']
-categories: ['slidecontent']
 ---
 
 <div class="diagram-group">

--- a/presentations/_posts/foundations/merge/0004-01-01-Conflicting-Merges.md
+++ b/presentations/_posts/foundations/merge/0004-01-01-Conflicting-Merges.md
@@ -2,7 +2,6 @@
 chapter: Merge
 layout: slide
 tags: ['merge']
-categories: ['slidecontent']
 ---
 	git add <conflicting-file>
 	git commit -m"<commit-message>"

--- a/presentations/_posts/foundations/merge/0005-01-01-Resolution-Selection.md
+++ b/presentations/_posts/foundations/merge/0005-01-01-Resolution-Selection.md
@@ -2,7 +2,6 @@
 chapter: Merge
 layout: slide
 tags: ['merge']
-categories: ['slidecontent']
 ---
 
 	git checkout --ours <file>

--- a/presentations/_posts/foundations/network/0001-01-01-Remotes.md
+++ b/presentations/_posts/foundations/network/0001-01-01-Remotes.md
@@ -2,7 +2,6 @@
 chapter: Network
 layout: slide
 tags: ['network','diagram']
-categories: ['slidecontent']
 ---
 
 <div class="diagram-group">

--- a/presentations/_posts/foundations/network/0002-01-01-Adding-a-Remote.md
+++ b/presentations/_posts/foundations/network/0002-01-01-Adding-a-Remote.md
@@ -2,7 +2,6 @@
 chapter: Network
 layout: slide
 tags: ['network']
-categories: ['slidecontent']
 ---
 
 	git remote add <name> <url>

--- a/presentations/_posts/foundations/network/0003-01-01-Remotes-Are-Immutable.md
+++ b/presentations/_posts/foundations/network/0003-01-01-Remotes-Are-Immutable.md
@@ -2,7 +2,6 @@
 chapter: Network
 layout: slide
 tags: ['network']
-categories: ['slidecontent']
 ---
 
 <div class="sticky">

--- a/presentations/_posts/foundations/network/0005-01-01-Listing-Remote-Branches.md
+++ b/presentations/_posts/foundations/network/0005-01-01-Listing-Remote-Branches.md
@@ -2,7 +2,6 @@
 chapter: Network
 layout: slide
 tags: ['network']
-categories: ['slidecontent']
 ---
 
 	#List remote branches

--- a/presentations/_posts/foundations/network/0006-01-01-Sharing-with-a-Push.md
+++ b/presentations/_posts/foundations/network/0006-01-01-Sharing-with-a-Push.md
@@ -2,7 +2,6 @@
 chapter: Network
 layout: slide
 tags: ['network']
-categories: ['slidecontent']
 ---
 
 	git push <remote> <branch>

--- a/presentations/_posts/foundations/network/0007-01-01-Pull-vs-Fetch.md
+++ b/presentations/_posts/foundations/network/0007-01-01-Pull-vs-Fetch.md
@@ -2,7 +2,6 @@
 chapter: Network
 layout: slide
 tags: ['network']
-categories: ['slidecontent']
 ---
 
 	git pull <remote> <branch>

--- a/presentations/_posts/foundations/rebase/0001-01-01-Reasons.md
+++ b/presentations/_posts/foundations/rebase/0001-01-01-Reasons.md
@@ -2,7 +2,6 @@
 chapter: Rebase
 layout: slide
 tags: ['rebase']
-categories: ['slidecontent']
 ---
 
 * Preparing for a merge

--- a/presentations/_posts/foundations/rebase/0002-01-01-Fast-Forward.md
+++ b/presentations/_posts/foundations/rebase/0002-01-01-Fast-Forward.md
@@ -2,7 +2,6 @@
 chapter: Rebase
 layout: slide
 tags: ['rebase','diagram']
-categories: ['slidecontent']
 ---
 
 <div class="diagram-group">

--- a/presentations/_posts/foundations/rebase/0003-01-01-Against-a-Branch.md
+++ b/presentations/_posts/foundations/rebase/0003-01-01-Against-a-Branch.md
@@ -2,7 +2,6 @@
 chapter: Rebase
 layout: slide
 tags: ['rebase']
-categories: ['slidecontent']
 ---
 
 	git checkout <feature-branch>

--- a/presentations/_posts/foundations/rebase/0004-01-01-Interactive.md
+++ b/presentations/_posts/foundations/rebase/0004-01-01-Interactive.md
@@ -2,7 +2,6 @@
 chapter: Rebase
 layout: slide
 tags: ['rebase','diagram']
-categories: ['slidecontent']
 ---
 
 

--- a/presentations/_posts/foundations/rebase/0005-01-01-Interactive-Command.md
+++ b/presentations/_posts/foundations/rebase/0005-01-01-Interactive-Command.md
@@ -2,7 +2,6 @@
 chapter: Rebase
 layout: slide
 tags: ['rebase']
-categories: ['slidecontent']
 ---
 
 	git rebase -i <ref>

--- a/presentations/_posts/foundations/reflog/0001-01-01-Restoring-by-Action.md
+++ b/presentations/_posts/foundations/reflog/0001-01-01-Restoring-by-Action.md
@@ -2,7 +2,6 @@
 chapter: Reflog
 layout: slide
 tags: ['reflog']
-categories: ['slidecontent']
 ---
 
 	git reflog -<n>

--- a/presentations/_posts/foundations/reflog/0002-01-01-Reflog-Video.md
+++ b/presentations/_posts/foundations/reflog/0002-01-01-Reflog-Video.md
@@ -2,7 +2,6 @@
 chapter: Reflog
 layout: slide
 tags: ['reflog']
-categories: ['slidecontent']
 ---
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/LIxxxMEoMMo?rel=0" frameborder="0" allowfullscreen></iframe>

--- a/presentations/_posts/foundations/reset/0001-01-01-Losing-Data-is-Difficult.md
+++ b/presentations/_posts/foundations/reset/0001-01-01-Losing-Data-is-Difficult.md
@@ -2,7 +2,6 @@
 chapter: Reset
 layout: slide
 tags: ['reset']
-categories: ['slidecontent']
 ---
 
 

--- a/presentations/_posts/foundations/reset/0002-01-01-Recover-from-History.md
+++ b/presentations/_posts/foundations/reset/0002-01-01-Recover-from-History.md
@@ -2,7 +2,6 @@
 chapter: Reset
 layout: slide
 tags: ['reset']
-categories: ['slidecontent']
 ---
 
 

--- a/presentations/_posts/foundations/reset/0003-01-01-Hard-Reset-Warning.md
+++ b/presentations/_posts/foundations/reset/0003-01-01-Hard-Reset-Warning.md
@@ -3,7 +3,6 @@ chapter: Reset
 heading: false
 layout: slide
 tags: ['reset']
-categories: ['slidecontent']
 ---
 
 <div class="sticky">

--- a/presentations/_posts/foundations/revert/0001-01-01-Restore-a-Prior-Commit.md
+++ b/presentations/_posts/foundations/revert/0001-01-01-Restore-a-Prior-Commit.md
@@ -2,7 +2,6 @@
 chapter: Revert
 layout: slide
 tags: ['revert']
-categories: ['slidecontent']
 ---
 
 Restore past patch set via new commit

--- a/presentations/_posts/foundations/rm-mv/0001-01-01-Tracking-States-Map.md
+++ b/presentations/_posts/foundations/rm-mv/0001-01-01-Tracking-States-Map.md
@@ -2,7 +2,6 @@
 chapter: Remove & Move
 layout: slide
 tags: ['rm-mv','diagram']
-categories: ['slidecontent']
 ---
 
 <div class="diagram-group">

--- a/presentations/_posts/foundations/rm-mv/0001-01-01-Tracking-States-in-Motion.md
+++ b/presentations/_posts/foundations/rm-mv/0001-01-01-Tracking-States-in-Motion.md
@@ -2,7 +2,6 @@
 chapter: Remove & Move
 layout: slide
 tags: ['rm-mv','diagram']
-categories: ['slidecontent']
 ---
 
 <div class="diagram-group">

--- a/presentations/_posts/foundations/rm-mv/0002-01-01-Deleting-Files.md
+++ b/presentations/_posts/foundations/rm-mv/0002-01-01-Deleting-Files.md
@@ -2,7 +2,6 @@
 chapter: Remove & Move
 layout: slide
 tags: ['rm-mv']
-categories: ['slidecontent']
 ---
 
 	# Directly remove & stage

--- a/presentations/_posts/foundations/rm-mv/0002-02-01-Stop-Tracking.md
+++ b/presentations/_posts/foundations/rm-mv/0002-02-01-Stop-Tracking.md
@@ -2,7 +2,6 @@
 chapter: Remove & Move
 layout: slide
 tags: ['rm-mv']
-categories: ['slidecontent']
 ---
 
 	# Stop file tracking

--- a/presentations/_posts/foundations/rm-mv/0007-01-01-Move-and-Stage.md
+++ b/presentations/_posts/foundations/rm-mv/0007-01-01-Move-and-Stage.md
@@ -2,7 +2,6 @@
 chapter: Remove & Move
 layout: slide
 tags: ['rm-mv']
-categories: ['slidecontent']
 ---
 
 	$ git mv <FILENAME> <NEWFILENAME>

--- a/presentations/_posts/foundations/rm-mv/0008-01-01-Similarity-Index.md
+++ b/presentations/_posts/foundations/rm-mv/0008-01-01-Similarity-Index.md
@@ -2,7 +2,6 @@
 chapter: Remove & Move
 layout: slide
 tags: ['rm-mv']
-categories: ['slidecontent']
 ---
 
 	# Renames shown

--- a/presentations/_posts/foundations/setup/0001-01-01-GitHub-Account.md
+++ b/presentations/_posts/foundations/setup/0001-01-01-GitHub-Account.md
@@ -3,7 +3,6 @@ chapter: Setup
 heading: false
 layout: slide
 tags: ['setup']
-categories: ['slidecontent']
 ---
 
 <div class="sticky">

--- a/presentations/_posts/foundations/setup/0002-01-01-GitHub-Installers.md
+++ b/presentations/_posts/foundations/setup/0002-01-01-GitHub-Installers.md
@@ -3,7 +3,6 @@ chapter: Setup
 heading: false
 layout: slide
 tags: ['setup']
-categories: ['slidecontent']
 ---
 
 <div class="sticky">

--- a/presentations/_posts/foundations/setup/0004-01-01-Git-Version.md
+++ b/presentations/_posts/foundations/setup/0004-01-01-Git-Version.md
@@ -2,7 +2,6 @@
 chapter: Setup
 layout: slide
 tags: ['setup']
-categories: ['slidecontent']
 ---
 
 Test the Install. Check your Version

--- a/presentations/_posts/foundations/stash/0001-01-01-Why-Use-Stash.md
+++ b/presentations/_posts/foundations/stash/0001-01-01-Why-Use-Stash.md
@@ -2,7 +2,6 @@
 chapter: Stash
 layout: slide
 tags: ['stash']
-categories: ['slidecontent']
 ---
 
 super quick branch that's local-only

--- a/presentations/_posts/foundations/stash/0002-01-01-Stash-Commands.md
+++ b/presentations/_posts/foundations/stash/0002-01-01-Stash-Commands.md
@@ -3,7 +3,6 @@ chapter: Stash
 heading: false
 layout: slide
 tags: ['stash']
-categories: ['slidecontent']
 ---
 
 	# Stash your pending changes

--- a/presentations/_posts/foundations/stash/0003-01-01-Stash-Commands.md
+++ b/presentations/_posts/foundations/stash/0003-01-01-Stash-Commands.md
@@ -3,7 +3,6 @@ chapter: Stash
 heading: false
 layout: slide
 tags: ['stash']
-categories: ['slidecontent']
 ---
 
 	# Merge & delete the latest stash

--- a/presentations/_posts/foundations/stash/0004-01-01-Stash-Commands.md
+++ b/presentations/_posts/foundations/stash/0004-01-01-Stash-Commands.md
@@ -3,7 +3,6 @@ chapter: Stash
 heading: false
 layout: slide
 tags: ['stash']
-categories: ['slidecontent']
 ---
 
 	# Diff stashed patches

--- a/presentations/_posts/foundations/stash/0005-01-01-Branch-from-a-Stash.md
+++ b/presentations/_posts/foundations/stash/0005-01-01-Branch-from-a-Stash.md
@@ -2,7 +2,6 @@
 chapter: Stash
 layout: slide
 tags: ['stash']
-categories: ['slidecontent']
 ---
 
 	$ git branch <branchname> <stash-name>

--- a/presentations/_posts/foundations/tag/0001-01-01-Tagging-Commits.md
+++ b/presentations/_posts/foundations/tag/0001-01-01-Tagging-Commits.md
@@ -3,7 +3,6 @@ chapter: Tag
 heading: false
 layout: slide
 tags: ['tag']
-categories: ['slidecontent']
 ---
 
 	# Annotated Tag with HEAD

--- a/presentations/_posts/foundations/tag/0002-01-01-Annotated-Tags.md
+++ b/presentations/_posts/foundations/tag/0002-01-01-Annotated-Tags.md
@@ -2,7 +2,6 @@
 chapter: Tag
 layout: slide
 tags: ['tag']
-categories: ['slidecontent']
 ---
 
 	git tag -a <TAGNAME>

--- a/presentations/_posts/foundations/tag/0003-01-01-Transmitting-Tags.md
+++ b/presentations/_posts/foundations/tag/0003-01-01-Transmitting-Tags.md
@@ -2,7 +2,6 @@
 chapter: Tag
 layout: slide
 tags: ['tag']
-categories: ['slidecontent']
 ---
 
 	# Push specific tag

--- a/presentations/_posts/foundations/treeish/0001-01-01-SHA-1.md
+++ b/presentations/_posts/foundations/treeish/0001-01-01-SHA-1.md
@@ -2,7 +2,6 @@
 chapter: Tree-ish
 layout: slide
 tags: ['treeish']
-categories: ['slidecontent']
 ---
 
 40 character hashes are hard to remember:

--- a/presentations/_posts/pages/getting-started/0001-01-01-create-the-repo.md
+++ b/presentations/_posts/pages/getting-started/0001-01-01-create-the-repo.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/getting-started"
-categories: ['slidecontent']
 ---
 
 From the GitHub site's top navigation bar, [create a new repository](https://github.com/new) owned by your personal account.

--- a/presentations/_posts/pages/getting-started/0002-01-01-clone-the-empty-repo.md
+++ b/presentations/_posts/pages/getting-started/0002-01-01-clone-the-empty-repo.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/getting-started"
-categories: ['slidecontent']
 ---
 
 Follow the on-page instructions to clone the repository locally to your computer:

--- a/presentations/_posts/pages/getting-started/0003-01-01-create-your-first-page.md
+++ b/presentations/_posts/pages/getting-started/0003-01-01-create-your-first-page.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/getting-started"
-categories: ['slidecontent']
 ---
 
 * Create an `index.html` file.  

--- a/presentations/_posts/pages/getting-started/0004-01-01-save-your-first-page.md
+++ b/presentations/_posts/pages/getting-started/0004-01-01-save-your-first-page.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/getting-started"
-categories: ['slidecontent']
 ---
 
 - Tell Git to add the file to the staging area.

--- a/presentations/_posts/pages/getting-started/0005-01-01-publish-your-first-page.md
+++ b/presentations/_posts/pages/getting-started/0005-01-01-publish-your-first-page.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/getting-started"
-categories: ['slidecontent']
 ---
 
 Push the changes to GitHub.

--- a/presentations/_posts/pages/getting-started/0006-01-01-take-a-look.md
+++ b/presentations/_posts/pages/getting-started/0006-01-01-take-a-look.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/getting-started"
-categories: ['slidecontent']
 ---
 
 1. Navigate to <br /> <span style="font-size: 0.9em;"">`http://[username].github.io/simple-site`</span>

--- a/presentations/_posts/pages/getting-started/0007-01-01-privacy.md
+++ b/presentations/_posts/pages/getting-started/0007-01-01-privacy.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/getting-started"
-categories: ['slidecontent']
 ---
 
 <div class="sticky">

--- a/presentations/_posts/pages/getting-started/0008-01-01-building-your-first-page.md
+++ b/presentations/_posts/pages/getting-started/0008-01-01-building-your-first-page.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/getting-started"
-categories: ['slidecontent']
 ---
 
  * The index file we created is just an HTML file. We can add any HTML we wish.

--- a/presentations/_posts/pages/jekyll/0001-01-01-introducing-jekyll.md
+++ b/presentations/_posts/pages/jekyll/0001-01-01-introducing-jekyll.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/jekyll"
-categories: ['slidecontent']
 ---
 
 * In addition to static file hosting, special files are transparently run through a powerful yet simple templating engine named [Jekyll](https://github.com/mojombo/jekyll) after every push to GitHub.

--- a/presentations/_posts/pages/jekyll/0002-01-01-inception.md
+++ b/presentations/_posts/pages/jekyll/0002-01-01-inception.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/jekyll"
-categories: ['slidecontent']
 heading: false
 ---
 

--- a/presentations/_posts/pages/jekyll/0003-01-01-github-pages-serving.md
+++ b/presentations/_posts/pages/jekyll/0003-01-01-github-pages-serving.md
@@ -5,7 +5,6 @@ layout: hydeside
 title: GitHub Pages Serving
 tags:
   - "pages/jekyll"
-categories: ['slidecontent']
 ---
 
 * Any file in the `gh-pages` branch of your repository will be transparently served via GitHub Pages including CSS, HTML, JPEGs, and JavaScript.

--- a/presentations/_posts/pages/jekyll/0004-01-01-jekyll-processing.md
+++ b/presentations/_posts/pages/jekyll/0004-01-01-jekyll-processing.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/jekyll"
-categories: ['slidecontent']
 ---
 
 All files with _front matter_ are run through Jekyll by default.

--- a/presentations/_posts/pages/jekyll/0005-01-01-yaml.md
+++ b/presentations/_posts/pages/jekyll/0005-01-01-yaml.md
@@ -5,7 +5,6 @@ layout: hydeside
 title: YAML
 tags:
   - "pages/jekyll"
-categories: ['slidecontent']
 ---
 
 * Jekyll uses a simple format called [YAML](http://www.yaml.org/) to communicate page properties

--- a/presentations/_posts/pages/jekyll/0006-01-01-front-matter-example.md
+++ b/presentations/_posts/pages/jekyll/0006-01-01-front-matter-example.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/jekyll"
-categories: ['slidecontent']
 ---
 
 At its most basic level, YAML is simply a set of properties and values separated by a colon (`:`). For example:

--- a/presentations/_posts/pages/jekyll/0007-01-01-yaml-behavior.md
+++ b/presentations/_posts/pages/jekyll/0007-01-01-yaml-behavior.md
@@ -5,7 +5,6 @@ layout: hydeside
 title: YAML Behavior
 tags:
   - "pages/jekyll"
-categories: ['slidecontent']
 ---
 
 * Any text-based file, regardless of the filetype, can be supplemented with YML front matter.

--- a/presentations/_posts/pages/layouts/0001-01-01-layouts.md
+++ b/presentations/_posts/pages/layouts/0001-01-01-layouts.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/layouts"
-categories: ['slidecontent']
 ---
 
 * Jekyll's most powerful (and simplest) feature is called "layouts"

--- a/presentations/_posts/pages/layouts/0002-01-01-layout-example.md
+++ b/presentations/_posts/pages/layouts/0002-01-01-layout-example.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/layouts"
-categories: ['slidecontent']
 ---
 
 * Let's say we pull the HTML out of `index.html` and save it to `_layouts/page.html` so that it looks like this:

--- a/presentations/_posts/pages/layouts/0003-01-01-but-wait,-there's-more!.md
+++ b/presentations/_posts/pages/layouts/0003-01-01-but-wait,-there's-more!.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/layouts"
-categories: ['slidecontent']
 ---
 
 We need to tell Jekyll to use our spiffy new layout. Let's add the following to the top of `index.html`:

--- a/presentations/_posts/pages/layouts/0004-01-01-lets-take-a-look.md
+++ b/presentations/_posts/pages/layouts/0004-01-01-lets-take-a-look.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydeside
 tags:
   - "pages/layouts"
-categories: ['slidecontent']
 ---
 
 * When we push our template to to GitHub pages Jekyll will replace <code>&#123;{ content }}</code> with the actual content, so lets...

--- a/presentations/_posts/pages/moar-jekyll/0001-01-01-includes.md
+++ b/presentations/_posts/pages/moar-jekyll/0001-01-01-includes.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydesides
 tags:
   - "pages/moar-jekyll"
-categories: ['slidecontent']
 ---
 
 * Includes allow you to reuse common elements

--- a/presentations/_posts/pages/moar-jekyll/0002-01-01-where-to-go-from-here.md
+++ b/presentations/_posts/pages/moar-jekyll/0002-01-01-where-to-go-from-here.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydesides
 tags:
   - "pages/moar-jekyll"
-categories: ['slidecontent']
 ---
 
 * Experiment with pretty [permalinks](https://github.com/mojombo/jekyll/wiki/Permalinks) (hint: `permalink` in a page's YML front matter will manually define its permalink)

--- a/presentations/_posts/pages/template-data/0001-01-01-using-template-data.md
+++ b/presentations/_posts/pages/template-data/0001-01-01-using-template-data.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydesides
 tags:
   - "pages/template-data"
-categories: ['slidecontent']
 ---
 
 * In addition to layouts, Jekyll also provides some more advanced template features

--- a/presentations/_posts/pages/template-data/0002-01-01-template-data-example.md
+++ b/presentations/_posts/pages/template-data/0002-01-01-template-data-example.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydesides
 tags:
   - "pages/template-data"
-categories: ['slidecontent']
 ---
 
 * Let's update the YML frontmatter on our `index.html` file to include:

--- a/presentations/_posts/pages/template-data/0003-01-01-updating-the-template.md
+++ b/presentations/_posts/pages/template-data/0003-01-01-updating-the-template.md
@@ -4,7 +4,6 @@ cover: true
 layout: hydesides
 tags:
   - "pages/template-data"
-categories: ['slidecontent']
 ---
 
 Now, we can go back to update our page layout in `_layouts/page.html` to add a page title like so:

--- a/presentations/_posts/pages/template-data/0004-01-01-lets-take-a-look-part-deux.md
+++ b/presentations/_posts/pages/template-data/0004-01-01-lets-take-a-look-part-deux.md
@@ -5,7 +5,6 @@ layout: hydesides
 title: Let's Take A Look Part Deux
 tags:
   - "pages/template-data"
-categories: ['slidecontent']
 ---
 
 * Let's commit and push our changes:


### PR DESCRIPTION
This tidies up all slides and discards the "categories" YAML field that was never used. Simplifies and avoids any confusion why this field is on the markdown files.
