### PR TITLE
Fix Oct 28 path & eventdate front matter to match title & date

### DIFF
--- a/classnotes/2013-10-28-private-workshop.md
+++ b/classnotes/2013-10-28-private-workshop.md
@@ -3,8 +3,8 @@ layout: bare
 title: Private Git Foundations Training
 description: Private Git Foundations Training Class Notes
 tags: [notes]
-path: classnotes/2013-09-17-private-git-foundations-class.md
-eventdate: 2013-09-17
+path: classnotes/2013-10-28-private-git-foundations-training.md
+eventdate: 2013-10-28
 ---
 
 ## Teachers


### PR DESCRIPTION
Currently shows as the following:

> 2013-09-17 • [Private Git Foundations Training](http://teach.github.com/classnotes/2013-10-28-private-workshop.html)

where its date listing is out of whack given the event date.
