### PR TITLE
Make "chat" link title editable on preroll bumper

### DIFF
--- a/presentations/_posts/bumpers/preroll/0001-01-01-Preroll.md
+++ b/presentations/_posts/bumpers/preroll/0001-01-01-Preroll.md
@@ -10,7 +10,7 @@ tags: ['preroll']
 
 ---
 
-## Classroom Chat
+<h1 contenteditable>Classroom Chat</h1>
 <div class="pseudoLink" contenteditable>githubtraining.campfirenow.com/---</div>
 
 


### PR DESCRIPTION
When chatroom is not in use for slide deck, an editable heading is useful for alternate subtitle, opening comment, etc.

![screen shot 2013-11-08 at 10 23 44 am](https://f.cloud.github.com/assets/352082/1499670/176a812e-4860-11e3-8925-99aa0c90c4fb.png)
